### PR TITLE
fix: changed logo size in qr code

### DIFF
--- a/dapps/v2Explorer/src/components/QRCode.tsx
+++ b/dapps/v2Explorer/src/components/QRCode.tsx
@@ -21,7 +21,11 @@ function QRCode({uri, size, theme = 'light'}: Props) {
       <Svg height={size} width={size}>
         {dots}
       </Svg>
-      <Image source={WCIsotype} style={[styles.logo, {width: size / 4}]} />
+      <Image
+        source={WCIsotype}
+        resizeMode="contain"
+        style={[styles.logo, {width: size / 4}]}
+      />
     </View>
   );
 }

--- a/dapps/v2Explorer/src/components/QRView.tsx
+++ b/dapps/v2Explorer/src/components/QRView.tsx
@@ -62,7 +62,7 @@ function QRView({uri, onBackPress}: Props) {
 
 const styles = StyleSheet.create({
   container: {
-    paddingBottom: 24,
+    paddingBottom: 32,
   },
   loader: {
     height: DEVICE_HEIGHT * 0.4,


### PR DESCRIPTION
## Description
Fixed issue with qr logo being cut

## Screenshots
### iOS
<img width="564" alt="Screen Shot 2023-03-27 at 14 55 42" src="https://user-images.githubusercontent.com/25931366/228025976-3d0eeeaf-bcc5-4763-95d9-90b2af701038.png">

### Android
<img width="652" alt="Screen Shot 2023-03-27 at 14 57 17" src="https://user-images.githubusercontent.com/25931366/228026334-28496142-f2a9-44af-bfba-70503b2e3d0c.png">
