### PR TITLE
chore: added resolutions to solve dependabot alerts

### DIFF
--- a/dapps/W3MWagmi/Gemfile
+++ b/dapps/W3MWagmi/Gemfile
@@ -8,4 +8,4 @@ gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
-gem 'rexml', '>= 3.3.6'
+gem "rexml", ">= 3.4.2"

--- a/dapps/W3MWagmi/Gemfile.lock
+++ b/dapps/W3MWagmi/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     public_suffix (4.0.7)
-    rexml (3.4.1)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
@@ -92,7 +92,7 @@ DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
   concurrent-ruby (< 1.3.4)
-  rexml (>= 3.3.6)
+  rexml (>= 3.4.2)
   xcodeproj (< 1.26.0)
 
 RUBY VERSION

--- a/dapps/W3MWagmi/package.json
+++ b/dapps/W3MWagmi/package.json
@@ -81,7 +81,7 @@
   },
   "packageManager": "yarn@3.6.4",
   "resolutions": {
-    "tar-fs": "2.1.3",
+    "tar-fs": "2.1.4",
     "ip": "2.0.1",
     "micromatch": "4.0.8",
     "@babel/helpers": "7.26.10",
@@ -100,6 +100,7 @@
     "viem": "2.37.9",
     "valtio": "2.1.8",
     "tmp": "0.2.4",
-    "on-headers": "1.1.0"
+    "on-headers": "1.1.0",
+    "fast-redact": "3.5.0"
   }
 }

--- a/dapps/W3MWagmi/yarn.lock
+++ b/dapps/W3MWagmi/yarn.lock
@@ -8694,10 +8694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-redact@npm:^3.0.0":
-  version: 3.3.0
-  resolution: "fast-redact@npm:3.3.0"
-  checksum: 3f7becc70a5a2662a9cbfdc52a4291594f62ae998806ee00315af307f32d9559dbf512146259a22739ee34401950ef47598c1f4777d33b0ed5027203d67f549c
+"fast-redact@npm:3.5.0":
+  version: 3.5.0
+  resolution: "fast-redact@npm:3.5.0"
+  checksum: ef03f0d1849da074a520a531ad299bf346417b790a643931ab4e01cb72275c8d55b60dc8512fb1f1818647b696790edefaa96704228db9f012da935faa1940af
   languageName: node
   linkType: hard
 
@@ -15127,15 +15127,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:2.1.3":
-  version: 2.1.3
-  resolution: "tar-fs@npm:2.1.3"
+"tar-fs@npm:2.1.4":
+  version: 2.1.4
+  resolution: "tar-fs@npm:2.1.4"
   dependencies:
     chownr: ^1.1.1
     mkdirp-classic: ^0.5.2
     pump: ^3.0.0
     tar-stream: ^2.1.4
-  checksum: 8dd66c20779c1fe535df5cf2ab5132705c12aba3ab95283f225a798329c5aaa8bbe92144c8e21bc9404f46a0d3ce59fc4997f5c42bafc55b6a225d4ad15aa966
+  checksum: a9e18e2e6114b8ac2568d7c2b42d006b1fe30d83957e4e75ba2361a889c2fc54e54236476782d06494e081358a393feacdf19311df12b3056c8a64dc1f7ed309
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependency updates:

* Updated the `rexml` gem version constraint in `Gemfile` to require at least `3.4.2`
* Updated the `tar-fs` package resolution in `package.json` from version `2.1.3` to `2.1.4`
* Added the `fast-redact` package at version `3.5.0` to the dependencies in `package.json`