### PR TITLE
chore: bump alerted deps

### DIFF
--- a/dapps/W3MWagmi/package.json
+++ b/dapps/W3MWagmi/package.json
@@ -50,8 +50,8 @@
     "react-native-toast-message": "2.2.1",
     "text-encoding": "^0.7.0",
     "tweetnacl": "1.0.3",
-    "viem": "2.37.9",
-    "wagmi": "2.17.5"
+    "viem": "2.38.5",
+    "wagmi": "2.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -95,12 +95,13 @@
     "form-data": "3.0.4",
     "sha.js": "2.4.12",
     "brace-expansion": "1.1.12",
-    "@walletconnect/ethereum-provider": "2.22.2",
-    "@walletconnect/universal-provider": "2.22.2",
-    "viem": "2.37.9",
+    "@walletconnect/ethereum-provider": "2.22.4",
+    "@walletconnect/universal-provider": "2.22.4",
+    "viem": "2.38.5",
     "valtio": "2.1.8",
     "tmp": "0.2.4",
     "on-headers": "1.1.0",
-    "fast-redact": "3.5.0"
+    "fast-redact": "3.5.0",
+    "hono": "4.10.2"
   }
 }

--- a/dapps/W3MWagmi/yarn.lock
+++ b/dapps/W3MWagmi/yarn.lock
@@ -5250,9 +5250,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/connectors@npm:5.11.2":
-  version: 5.11.2
-  resolution: "@wagmi/connectors@npm:5.11.2"
+"@wagmi/connectors@npm:6.1.1":
+  version: 6.1.1
+  resolution: "@wagmi/connectors@npm:6.1.1"
   dependencies:
     "@base-org/account": 1.1.1
     "@coinbase/wallet-sdk": 4.3.6
@@ -5262,21 +5262,21 @@ __metadata:
     "@safe-global/safe-apps-sdk": 9.1.0
     "@walletconnect/ethereum-provider": 2.21.1
     cbw-sdk: "npm:@coinbase/wallet-sdk@3.9.3"
-    porto: 0.2.19
+    porto: 0.2.34
   peerDependencies:
-    "@wagmi/core": 2.21.2
+    "@wagmi/core": 2.22.1
     typescript: ">=5.0.4"
     viem: 2.x
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 2cd5937e5ee5e84e3085dfa86d562381c12c3635da185d148d8a0cbf07af8a414a8636e0b16066bd4b9f6757def7bf9e52e29c5a7fb79cf6c501ce160f8b4a0c
+  checksum: 9d74215d82d1eeaf208c50fa5cf2e159b505e363cbf6fb92dbfea458c6dd88f0fe9caa7a3e946140322beeb0fa4ee9f2a01f8ed3bfd510648fc23a922613bda9
   languageName: node
   linkType: hard
 
-"@wagmi/core@npm:2.21.2":
-  version: 2.21.2
-  resolution: "@wagmi/core@npm:2.21.2"
+"@wagmi/core@npm:2.22.1":
+  version: 2.22.1
+  resolution: "@wagmi/core@npm:2.22.1"
   dependencies:
     eventemitter3: 5.0.1
     mipd: 0.0.7
@@ -5290,7 +5290,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 496f083b79876451500826c68ac7acd8af34ae2f926c18f439313ad4142383156b416db8798ba0b886ed5f34131449d3b3d2496dbbbdd5139d74bc26b068a533
+  checksum: 5f9621024cb2a86825d6d1c62bb0d795f10dc60a16b4cc9ac78c72533889066a00c37ef8582169d5533d7d4061440397b1fa4cf86e69424036759e3413b6a765
   languageName: node
   linkType: hard
 
@@ -5310,9 +5310,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:2.22.2":
-  version: 2.22.2
-  resolution: "@walletconnect/core@npm:2.22.2"
+"@walletconnect/core@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@walletconnect/core@npm:2.22.4"
   dependencies:
     "@walletconnect/heartbeat": 1.2.2
     "@walletconnect/jsonrpc-provider": 1.0.14
@@ -5320,18 +5320,18 @@ __metadata:
     "@walletconnect/jsonrpc-utils": 1.0.8
     "@walletconnect/jsonrpc-ws-connection": 1.0.16
     "@walletconnect/keyvaluestorage": 1.1.1
-    "@walletconnect/logger": 2.1.2
+    "@walletconnect/logger": 3.0.0
     "@walletconnect/relay-api": 1.0.11
     "@walletconnect/relay-auth": 1.1.0
     "@walletconnect/safe-json": 1.0.2
     "@walletconnect/time": 1.0.2
-    "@walletconnect/types": 2.22.2
-    "@walletconnect/utils": 2.22.2
+    "@walletconnect/types": 2.22.4
+    "@walletconnect/utils": 2.22.4
     "@walletconnect/window-getters": 1.0.1
     es-toolkit: 1.39.3
     events: 3.3.0
     uint8arrays: 3.1.1
-  checksum: 9be633137efc75d9081e168f8803c2238f96b02245c1dccbc8e8e2245a050c9f84cf3db1414db51b2983fa9b642b657d372e337fce88cc2e122cf0decc050836
+  checksum: e44dae220540d43978d9802b8d3e0499a4a5cf2f17665e41e5b4aa42cd03a07b2b117bacb7a49867c0ca8fbfc58169728d1f8fb98ec73a14505bc34eb7594b33
   languageName: node
   linkType: hard
 
@@ -5344,9 +5344,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/ethereum-provider@npm:2.22.2":
-  version: 2.22.2
-  resolution: "@walletconnect/ethereum-provider@npm:2.22.2"
+"@walletconnect/ethereum-provider@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@walletconnect/ethereum-provider@npm:2.22.4"
   dependencies:
     "@reown/appkit": 1.8.9
     "@walletconnect/jsonrpc-http-connection": 1.0.8
@@ -5354,12 +5354,13 @@ __metadata:
     "@walletconnect/jsonrpc-types": 1.0.4
     "@walletconnect/jsonrpc-utils": 1.0.8
     "@walletconnect/keyvaluestorage": 1.1.1
-    "@walletconnect/sign-client": 2.22.2
-    "@walletconnect/types": 2.22.2
-    "@walletconnect/universal-provider": 2.22.2
-    "@walletconnect/utils": 2.22.2
+    "@walletconnect/logger": 3.0.0
+    "@walletconnect/sign-client": 2.22.4
+    "@walletconnect/types": 2.22.4
+    "@walletconnect/universal-provider": 2.22.4
+    "@walletconnect/utils": 2.22.4
     events: 3.3.0
-  checksum: 0077e7903fd4882499de953afdf989090b68ae419da7d390022beadf835c3a06a0b63b36e84b6e2edd2d5304702d79a38f08f8dbb66a171465794258c61989c0
+  checksum: 84321091206a5455c711e7245efc96b3ea1a28b72e3f898e9af2bcf72466a1cca7828f2f1075a27f83d62715961dfebf4d3a8e91fe0d17ee22c8d6c2144fd86d
   languageName: node
   linkType: hard
 
@@ -5466,6 +5467,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/logger@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@walletconnect/logger@npm:3.0.0"
+  dependencies:
+    "@walletconnect/safe-json": ^1.0.2
+    pino: 10.0.0
+  checksum: cfc6e8f9633124e366b8e8d66be4cf5367482f8a937eed1fcaf3b99b624e580e32577dcc510f3da25fcd660c1405f3de286353ea8e97a063c3f8d28679572e8e
+  languageName: node
+  linkType: hard
+
 "@walletconnect/react-native-compat@npm:2.22.2":
   version: 2.22.2
   resolution: "@walletconnect/react-native-compat@npm:2.22.2"
@@ -5517,20 +5528,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/sign-client@npm:2.22.2":
-  version: 2.22.2
-  resolution: "@walletconnect/sign-client@npm:2.22.2"
+"@walletconnect/sign-client@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@walletconnect/sign-client@npm:2.22.4"
   dependencies:
-    "@walletconnect/core": 2.22.2
+    "@walletconnect/core": 2.22.4
     "@walletconnect/events": 1.0.1
     "@walletconnect/heartbeat": 1.2.2
     "@walletconnect/jsonrpc-utils": 1.0.8
-    "@walletconnect/logger": 2.1.2
+    "@walletconnect/logger": 3.0.0
     "@walletconnect/time": 1.0.2
-    "@walletconnect/types": 2.22.2
-    "@walletconnect/utils": 2.22.2
+    "@walletconnect/types": 2.22.4
+    "@walletconnect/utils": 2.22.4
     events: 3.3.0
-  checksum: 9a6dfe1aaaf31211caea311f79dfac3706474bd6419aacee822ef8e022ad0e250d74867d2f89e1cf7eed97bfbc0783048ca8a2f0c0aa6f71cc6a2fd903cb44d8
+  checksum: 6488caec70b4a791f592dacead071e8bc9da7700f4575f56e13ed9d8a04de40e80f2e5c0db2d7012f6d1cbc57583483ddb87da6c62c5609fc9e2753b3fd3bd10
   languageName: node
   linkType: hard
 
@@ -5543,23 +5554,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.22.2":
-  version: 2.22.2
-  resolution: "@walletconnect/types@npm:2.22.2"
+"@walletconnect/types@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@walletconnect/types@npm:2.22.4"
   dependencies:
     "@walletconnect/events": 1.0.1
     "@walletconnect/heartbeat": 1.2.2
     "@walletconnect/jsonrpc-types": 1.0.4
     "@walletconnect/keyvaluestorage": 1.1.1
-    "@walletconnect/logger": 2.1.2
+    "@walletconnect/logger": 3.0.0
     events: 3.3.0
-  checksum: 62e8e1533c76927e80ae2693fd29c6318a44864aacc893ef7912d104e31fd0d1507b77f203a2556bf87cd46aa70b5d0b7bd1a24488e43508c8476d2c8b11c61b
+  checksum: f74c72524c7433b2e37f17ba4a30a8f4ef35a821b143deb385752eded99097dd41756c3ad536624ebf37b5304a9a4807ec1235e33fdb66e9f822a743c38581b8
   languageName: node
   linkType: hard
 
-"@walletconnect/universal-provider@npm:2.22.2":
-  version: 2.22.2
-  resolution: "@walletconnect/universal-provider@npm:2.22.2"
+"@walletconnect/universal-provider@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@walletconnect/universal-provider@npm:2.22.4"
   dependencies:
     "@walletconnect/events": 1.0.1
     "@walletconnect/jsonrpc-http-connection": 1.0.8
@@ -5567,19 +5578,19 @@ __metadata:
     "@walletconnect/jsonrpc-types": 1.0.4
     "@walletconnect/jsonrpc-utils": 1.0.8
     "@walletconnect/keyvaluestorage": 1.1.1
-    "@walletconnect/logger": 2.1.2
-    "@walletconnect/sign-client": 2.22.2
-    "@walletconnect/types": 2.22.2
-    "@walletconnect/utils": 2.22.2
+    "@walletconnect/logger": 3.0.0
+    "@walletconnect/sign-client": 2.22.4
+    "@walletconnect/types": 2.22.4
+    "@walletconnect/utils": 2.22.4
     es-toolkit: 1.39.3
     events: 3.3.0
-  checksum: ded0f49556aa427f25e65eb8c2dfed52aef692b3ced20e7862a5c4159f72900dd22e2de3441384b944cb91963fdfad9dd3bfe68c8a79bf47c30aba23ec0a1327
+  checksum: bcb909a40910e9ae55d765db2d91e7b41534dd50141a7e7c2f025a3b96ee5c9ea7d36f4c89c1fc5a149f0828db0e9f3374c9afec7f530775c7665599dab63f37
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:2.22.2":
-  version: 2.22.2
-  resolution: "@walletconnect/utils@npm:2.22.2"
+"@walletconnect/utils@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@walletconnect/utils@npm:2.22.4"
   dependencies:
     "@msgpack/msgpack": 3.1.2
     "@noble/ciphers": 1.3.0
@@ -5588,12 +5599,12 @@ __metadata:
     "@scure/base": 1.2.6
     "@walletconnect/jsonrpc-utils": 1.0.8
     "@walletconnect/keyvaluestorage": 1.1.1
-    "@walletconnect/logger": 2.1.2
+    "@walletconnect/logger": 3.0.0
     "@walletconnect/relay-api": 1.0.11
     "@walletconnect/relay-auth": 1.1.0
     "@walletconnect/safe-json": 1.0.2
     "@walletconnect/time": 1.0.2
-    "@walletconnect/types": 2.22.2
+    "@walletconnect/types": 2.22.4
     "@walletconnect/window-getters": 1.0.1
     "@walletconnect/window-metadata": 1.0.1
     blakejs: 1.2.1
@@ -5601,7 +5612,7 @@ __metadata:
     detect-browser: 5.3.0
     ox: 0.9.3
     uint8arrays: 3.1.1
-  checksum: 65393406843b684d7de064a593ca37fb465859217744333ef53892d11415bb8cf48827b83311185370d06243f52c7efb131007874e41a06a599c508b7998fd12
+  checksum: fec7eb9830caf6f89877a47867896131e10f94adf61e2c8f0f4cdfcef42d0e43ffc21f1dc94195301399e4895e97d4f3405c74e375af5a45d6b69c09d27c2054
   languageName: node
   linkType: hard
 
@@ -9485,10 +9496,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.9.6":
-  version: 4.9.9
-  resolution: "hono@npm:4.9.9"
-  checksum: af3d5374802d77c3bef1e90c62cbb8c31d8f6cc79b587827c2b5e6c7ce5aca3a90c20f6034ae1e630e6245125ca27a8e681c3eb98d8cee9665f64955d2a4250d
+"hono@npm:4.10.2":
+  version: 4.10.2
+  resolution: "hono@npm:4.10.2"
+  checksum: 388967f186e993850184eda3d8ba5b7bccd5b32f31d710b9bf05a7a62f319c60d51bfd0147c3d5bc012a9b956a5ae5113b134e738532944b3e93e0d606b7bc08
   languageName: node
   linkType: hard
 
@@ -12452,6 +12463,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-exit-leak-free@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "on-exit-leak-free@npm:2.1.2"
+  checksum: 6ce7acdc7b9ceb51cf029b5239cbf41937ee4c8dcd9d4e475e1777b41702564d46caa1150a744e00da0ac6d923ab83471646a39a4470f97481cf6e2d8d253c3f
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -12918,6 +12936,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pino-abstract-transport@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pino-abstract-transport@npm:2.0.0"
+  dependencies:
+    split2: ^4.0.0
+  checksum: 4db0cd8a1a7b6d13e76dbb58e6adc057c39e4591c70f601f4a427c030d57dff748ab53954e1ecd3aa6e21c1a22dd38de96432606c6d906a7b9f610543bf1d6e2
+  languageName: node
+  linkType: hard
+
 "pino-abstract-transport@npm:v0.5.0":
   version: 0.5.0
   resolution: "pino-abstract-transport@npm:0.5.0"
@@ -12932,6 +12959,34 @@ __metadata:
   version: 4.0.0
   resolution: "pino-std-serializers@npm:4.0.0"
   checksum: 89d487729b58c9d3273a0ee851ead068d6d2e2ccc1af8e1c1d28f1b3442423679bec7ec04d9a2aba36f94f335e82be9f4de19dc4fbc161e71c136aaa15b85ad3
+  languageName: node
+  linkType: hard
+
+"pino-std-serializers@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pino-std-serializers@npm:7.0.0"
+  checksum: 08cd1d7b7adc4cfca39e42c2d5fd21bcf4513153734e7b8fa278b0e9e9f62df78c4c202886343fe882a462539c931cb8110b661775ad7f7217c96856795b5a86
+  languageName: node
+  linkType: hard
+
+"pino@npm:10.0.0":
+  version: 10.0.0
+  resolution: "pino@npm:10.0.0"
+  dependencies:
+    atomic-sleep: ^1.0.0
+    on-exit-leak-free: ^2.1.0
+    pino-abstract-transport: ^2.0.0
+    pino-std-serializers: ^7.0.0
+    process-warning: ^5.0.0
+    quick-format-unescaped: ^4.0.3
+    real-require: ^0.2.0
+    safe-stable-stringify: ^2.3.1
+    slow-redact: ^0.3.0
+    sonic-boom: ^4.0.1
+    thread-stream: ^3.0.0
+  bin:
+    pino: bin.js
+  checksum: 76dd61c2928e9d26a9049bae5ee23d2ee913eecb5798034e31f44be3f143ad3f356a66259e722c978527587492153e2dc2d04829055d43a2e313df8132ee4d0f
   languageName: node
   linkType: hard
 
@@ -13042,11 +13097,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"porto@npm:0.2.19":
-  version: 0.2.19
-  resolution: "porto@npm:0.2.19"
+"porto@npm:0.2.34":
+  version: 0.2.34
+  resolution: "porto@npm:0.2.34"
   dependencies:
-    hono: ^4.9.6
+    hono: ^4.10.3
     idb-keyval: ^6.2.1
     mipd: ^0.0.7
     ox: ^0.9.6
@@ -13055,22 +13110,34 @@ __metadata:
   peerDependencies:
     "@tanstack/react-query": ">=5.59.0"
     "@wagmi/core": ">=2.16.3"
+    expo-auth-session: ">=7.0.8"
+    expo-crypto: ">=15.0.7"
+    expo-web-browser: ">=15.0.8"
     react: ">=18"
+    react-native: ">=0.81.4"
     typescript: ">=5.4.0"
     viem: ">=2.37.0"
     wagmi: ">=2.0.0"
   peerDependenciesMeta:
     "@tanstack/react-query":
       optional: true
+    expo-auth-session:
+      optional: true
+    expo-crypto:
+      optional: true
+    expo-web-browser:
+      optional: true
     react:
+      optional: true
+    react-native:
       optional: true
     typescript:
       optional: true
     wagmi:
       optional: true
   bin:
-    porto: _dist/cli/bin/index.js
-  checksum: 44e8ab54e0beb5b8f850b93f847ea1807de84e6c4c15024d187ba1bdfe56e03b1d0e3addc33650b19fc6e453b76c3b68a60f2acc106b57602c519449ca72d799
+    porto: dist/cli/bin/index.js
+  checksum: 4ed7b0c6838fa9357a021a2261744b4a11a8d76881da655bc74ef9eacce3a293c40b08882e330336a049ac36c0639a5a0f5afc64fb5a233c81c11f99bad0278a
   languageName: node
   linkType: hard
 
@@ -13194,6 +13261,13 @@ __metadata:
   version: 1.0.0
   resolution: "process-warning@npm:1.0.0"
   checksum: c708a03241deec3cabaeee39c4f9ee8c4d71f1c5ef9b746c8252cdb952a6059068cfcdaf348399775244cbc441b6ae5e26a9c87ed371f88335d84f26d19180f9
+  languageName: node
+  linkType: hard
+
+"process-warning@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "process-warning@npm:5.0.0"
+  checksum: 99bce32133a67d45f3efff1202d0895548da3464501ad2acf6ad6d5f6a879b246868f2f382ff8a5872e2bb17b0d800dc1961885947ea9b3344db9cb91405cd88
   languageName: node
   linkType: hard
 
@@ -13758,6 +13832,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"real-require@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "real-require@npm:0.2.0"
+  checksum: fa060f19f2f447adf678d1376928c76379dce5f72bd334da301685ca6cdcb7b11356813332cc243c88470796bc2e2b1e2917fc10df9143dd93c2ea608694971d
+  languageName: node
+  linkType: hard
+
 "recast@npm:^0.21.0":
   version: 0.21.5
   resolution: "recast@npm:0.21.5"
@@ -14182,8 +14263,8 @@ __metadata:
     text-encoding: ^0.7.0
     tweetnacl: 1.0.3
     typescript: 5.0.4
-    viem: 2.37.9
-    wagmi: 2.17.5
+    viem: 2.38.5
+    wagmi: 2.19.0
   languageName: unknown
   linkType: soft
 
@@ -14266,6 +14347,13 @@ __metadata:
   version: 2.4.3
   resolution: "safe-stable-stringify@npm:2.4.3"
   checksum: 3aeb64449706ee1f5ad2459fc99648b131d48e7a1fbb608d7c628020177512dc9d94108a5cb61bbc953985d313d0afea6566d243237743e02870490afef04b43
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: d3ce103ed43c6c2f523e39607208bfb1c73aa48179fc5be53c3aa97c118390bffd4d55e012f5393b982b65eb3e0ee954dd57b547930d3f242b0053dcdb923d17
   languageName: node
   linkType: hard
 
@@ -14604,6 +14692,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slow-redact@npm:^0.3.0":
+  version: 0.3.2
+  resolution: "slow-redact@npm:0.3.2"
+  checksum: 7c5264f93a309684a3a2622d0017af024174f31b4b82921b19791d8a707e8bc5dca56918df685dada23ccc84fbe2cc0cc954a739989c9167d5f60c05fa639f22
+  languageName: node
+  linkType: hard
+
 "slugify@npm:^1.3.4, slugify@npm:^1.6.6":
   version: 1.6.6
   resolution: "slugify@npm:1.6.6"
@@ -14667,6 +14762,15 @@ __metadata:
   dependencies:
     atomic-sleep: ^1.0.0
   checksum: c7f9c89f931d7f60f8e0741551a729f0d81e6dc407a99420fc847a9a4c25af048a615b1188ab3c4f1fb3708fe4904973ddab6ebcc8ed5b78b50ab81a99045910
+  languageName: node
+  linkType: hard
+
+"sonic-boom@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "sonic-boom@npm:4.2.0"
+  dependencies:
+    atomic-sleep: ^1.0.0
+  checksum: e5e1ffdd3bcb0dee3bf6f7b2ff50dd3ffa2df864dc9d53463f33e225021a28601e91d0ec7e932739824bafd6f4ff3b7090939ac3e34ab1022e01692b41f7e8a3
   languageName: node
   linkType: hard
 
@@ -15275,6 +15379,15 @@ __metadata:
   dependencies:
     real-require: ^0.1.0
   checksum: 0547795a8f357ba1ac0dba29c71f965182e29e21752951a04a7167515ee37524bfba6c410f31e65a01a8d3e5b93400b812889aa09523e38ce4d744c894ffa6c0
+  languageName: node
+  linkType: hard
+
+"thread-stream@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "thread-stream@npm:3.1.0"
+  dependencies:
+    real-require: ^0.2.0
+  checksum: 3c5b494ce776f832dfd696792cc865f78c1e850db93e07979349bbc1a5845857cd447aea95808892906cc0178a2fd3233907329f3376e7fc9951e2833f5b7896
   languageName: node
   linkType: hard
 
@@ -15946,9 +16059,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:2.37.9":
-  version: 2.37.9
-  resolution: "viem@npm:2.37.9"
+"viem@npm:2.38.5":
+  version: 2.38.5
+  resolution: "viem@npm:2.38.5"
   dependencies:
     "@noble/curves": 1.9.1
     "@noble/hashes": 1.8.0
@@ -15963,7 +16076,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 4c7ba35a556a36a1a25a7af0bfbb5f2f499b67fa37ccc25e397eee78bd9766b1261d551be7d2687bc917ac167ca55a970ade20486cf9cc215754572f83240a28
+  checksum: 02aa8b7177a3cca2a876253f1ecb7110242950392fbcb31575b281a8eed269e8a6e71f90d7ea8ad7a5f10e9516a98c4cb1eaaf42ae2852ecae1e6b182867b0fc
   languageName: node
   linkType: hard
 
@@ -15974,12 +16087,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:2.17.5":
-  version: 2.17.5
-  resolution: "wagmi@npm:2.17.5"
+"wagmi@npm:2.19.0":
+  version: 2.19.0
+  resolution: "wagmi@npm:2.19.0"
   dependencies:
-    "@wagmi/connectors": 5.11.2
-    "@wagmi/core": 2.21.2
+    "@wagmi/connectors": 6.1.1
+    "@wagmi/core": 2.22.1
     use-sync-external-store: 1.4.0
   peerDependencies:
     "@tanstack/react-query": ">=5.0.0"
@@ -15989,7 +16102,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 12e0226f42e584377d24dfcf7e48dd27416481210b53019506fccd5d15f54aa48ad17415607817a5b9331c04d806e4166470f3de14ecfc9eff35c34f6d18d47d
+  checksum: 6331aaba2d73b7f81a25e0a7820554edae2193627a3d4e2a4ab96b25d65bd5ff72cd24de08c59c4bb9d438725280ff0d401cd1f152fa971eead37540d2dfdb79
   languageName: node
   linkType: hard
 

--- a/dapps/appkit-expo-wagmi/package-lock.json
+++ b/dapps/appkit-expo-wagmi/package-lock.json
@@ -20,7 +20,7 @@
         "@reown/appkit-solana-react-native": "2.0.1",
         "@reown/appkit-wagmi-react-native": "2.0.1",
         "@tanstack/react-query": "^5.81.5",
-        "@walletconnect/react-native-compat": "2.22.2",
+        "@walletconnect/react-native-compat": "2.22.4",
         "expo": "54.0.12",
         "expo-application": "~7.0.7",
         "expo-blur": "~15.0.7",
@@ -48,8 +48,8 @@
         "react-native-web": "^0.21.0",
         "react-native-worklets": "0.5.1",
         "text-encoding": "0.7.0",
-        "viem": "2.38.0",
-        "wagmi": "2.17.5"
+        "viem": "2.38.5",
+        "wagmi": "2.19.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -3037,6 +3037,16 @@
       "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
@@ -3659,6 +3669,15 @@
       "license": "(MIT OR Apache-2.0)",
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@phosphor-icons/webcomponents": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/webcomponents/-/webcomponents-2.1.5.tgz",
+      "integrity": "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4519,24 +4538,28 @@
       }
     },
     "node_modules/@reown/appkit": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.8.tgz",
-      "integrity": "sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.9.tgz",
+      "integrity": "sha512-e3N2DAzf3Xv3jnoD8IsUo0/Yfwuhk7npwJBe1+9rDJIRwgPsyYcCLD4gKPDFC5IUIfOLqK7YtGOh9oPEUnIWpw==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-pay": "1.7.8",
-        "@reown/appkit-polyfills": "1.7.8",
-        "@reown/appkit-scaffold-ui": "1.7.8",
-        "@reown/appkit-ui": "1.7.8",
-        "@reown/appkit-utils": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
-        "@walletconnect/types": "2.21.0",
-        "@walletconnect/universal-provider": "2.21.0",
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-controllers": "1.8.9",
+        "@reown/appkit-pay": "1.8.9",
+        "@reown/appkit-polyfills": "1.8.9",
+        "@reown/appkit-scaffold-ui": "1.8.9",
+        "@reown/appkit-ui": "1.8.9",
+        "@reown/appkit-utils": "1.8.9",
+        "@reown/appkit-wallet": "1.8.9",
+        "@walletconnect/universal-provider": "2.21.9",
         "bs58": "6.0.0",
-        "valtio": "1.13.2",
-        "viem": ">=2.29.0"
+        "semver": "7.7.2",
+        "valtio": "2.1.7",
+        "viem": ">=2.37.9"
+      },
+      "optionalDependencies": {
+        "@lit/react": "1.0.8"
       }
     },
     "node_modules/@reown/appkit-bitcoin-react-native": {
@@ -4554,14 +4577,14 @@
       }
     },
     "node_modules/@reown/appkit-common": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.8.tgz",
-      "integrity": "sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.9.tgz",
+      "integrity": "sha512-drseYLBDqcQR2WvhfAwrKRiDJdTmsmwZsRBg72sxQDvAwxfKNSmiqsqURq5c/Q9SeeTwclge58Dyq7Ijo6TeeQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "big.js": "6.2.2",
         "dayjs": "1.11.13",
-        "viem": ">=2.29.0"
+        "viem": ">=2.37.9"
       }
     },
     "node_modules/@reown/appkit-common-react-native": {
@@ -4585,16 +4608,16 @@
       "license": "MIT"
     },
     "node_modules/@reown/appkit-controllers": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.8.tgz",
-      "integrity": "sha512-IdXlJlivrlj6m63VsGLsjtPHHsTWvKGVzWIP1fXZHVqmK+rZCBDjCi9j267Rb9/nYRGHWBtlFQhO8dK35WfeDA==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.9.tgz",
+      "integrity": "sha512-/8hgFAgiYCTDG3gSxJr8hXy6GnO28UxN8JOXFUEi5gOODy7d3+3Jwm+7OEghf7hGKrShDedibsXdXKdX1PUT+g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
-        "@walletconnect/universal-provider": "2.21.0",
-        "valtio": "1.13.2",
-        "viem": ">=2.29.0"
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-wallet": "1.8.9",
+        "@walletconnect/universal-provider": "2.21.9",
+        "valtio": "2.1.7",
+        "viem": ">=2.37.9"
       }
     },
     "node_modules/@reown/appkit-core-react-native": {
@@ -4615,24 +4638,24 @@
       }
     },
     "node_modules/@reown/appkit-pay": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
-      "integrity": "sha512-OSGQ+QJkXx0FEEjlpQqIhT8zGJKOoHzVnyy/0QFrl3WrQTjCzg0L6+i91Ad5Iy1zb6V5JjqtfIFpRVRWN4M3pw==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.9.tgz",
+      "integrity": "sha512-AEmaPqxnzjawSRFenyiTtq0vjKM5IPb2CTD9wa+OMXFpe6FissO+1Eg1H47sfdrycZCvUizSRmQmYqkJaI8BCw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-ui": "1.7.8",
-        "@reown/appkit-utils": "1.7.8",
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-controllers": "1.8.9",
+        "@reown/appkit-ui": "1.8.9",
+        "@reown/appkit-utils": "1.8.9",
         "lit": "3.3.0",
-        "valtio": "1.13.2"
+        "valtio": "2.1.7"
       }
     },
     "node_modules/@reown/appkit-polyfills": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.8.tgz",
-      "integrity": "sha512-W/kq786dcHHAuJ3IV2prRLEgD/2iOey4ueMHf1sIFjhhCGMynMkhsOhQMUH0tzodPqUgAC494z4bpIDYjwWXaA==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.9.tgz",
+      "integrity": "sha512-33YCU8dxe4UkpNf9qCAaHx5crSoEu6tbmZxE/0eEPCYRDRXoiH9VGiN7xwTDOVduacg/U8H6/32ibmYZKnRk5Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
       }
@@ -4659,16 +4682,16 @@
       }
     },
     "node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.8.tgz",
-      "integrity": "sha512-RCeHhAwOrIgcvHwYlNWMcIDibdI91waaoEYBGw71inE0kDB8uZbE7tE6DAXJmDkvl0qPh+DqlC4QbJLF1FVYdQ==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.9.tgz",
+      "integrity": "sha512-F7PSM1nxvlvj2eu8iL355GzvCNiL8RKiCqT1zag8aB4QpxjU24l+vAF6debtkg4HY8nJOyDifZ7Z1jkKrHlIDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-ui": "1.7.8",
-        "@reown/appkit-utils": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-controllers": "1.8.9",
+        "@reown/appkit-ui": "1.8.9",
+        "@reown/appkit-utils": "1.8.9",
+        "@reown/appkit-wallet": "1.8.9",
         "lit": "3.3.0"
       }
     },
@@ -4691,14 +4714,15 @@
       }
     },
     "node_modules/@reown/appkit-ui": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.8.tgz",
-      "integrity": "sha512-1hjCKjf6FLMFzrulhl0Y9Vb9Fu4royE+SXCPSWh4VhZhWqlzUFc7kutnZKx8XZFVQH4pbBvY62SpRC93gqoHow==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.9.tgz",
+      "integrity": "sha512-WR17ql77KOMKfyDh7RW4oSfmj+p5gIl0u8Wmopzbx5Hd0HcPVZ5HmTDpwOM9WCSxYcin0fsSAoI+nVdvrhWNtw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-controllers": "1.8.9",
+        "@reown/appkit-wallet": "1.8.9",
         "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
@@ -4720,22 +4744,23 @@
       }
     },
     "node_modules/@reown/appkit-utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.8.tgz",
-      "integrity": "sha512-8X7UvmE8GiaoitCwNoB86pttHgQtzy4ryHZM9kQpvjQ0ULpiER44t1qpVLXNM4X35O0v18W0Dk60DnYRMH2WRw==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.9.tgz",
+      "integrity": "sha512-U9hx4h7tIE7ha/QWKjZpZc/imaLumdwe0QNdku9epjp/npXVjGuwUrW5mj8yWNSkjtQpY/BEItNdDAUKZ7rrjw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-polyfills": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-controllers": "1.8.9",
+        "@reown/appkit-polyfills": "1.8.9",
+        "@reown/appkit-wallet": "1.8.9",
+        "@wallet-standard/wallet": "1.1.0",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/universal-provider": "2.21.0",
-        "valtio": "1.13.2",
-        "viem": ">=2.29.0"
+        "@walletconnect/universal-provider": "2.21.9",
+        "valtio": "2.1.7",
+        "viem": ">=2.37.9"
       },
       "peerDependencies": {
-        "valtio": "1.13.2"
+        "valtio": "2.1.7"
       }
     },
     "node_modules/@reown/appkit-wagmi-react-native": {
@@ -4758,29 +4783,15 @@
       }
     },
     "node_modules/@reown/appkit-wallet": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
-      "integrity": "sha512-kspz32EwHIOT/eg/ZQbFPxgXq0B/olDOj3YMu7gvLEFz4xyOFd/wgzxxAXkp5LbG4Cp++s/elh79rVNmVFdB9A==",
-      "license": "Apache-2.0",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.9.tgz",
+      "integrity": "sha512-rcAXvkzOVG4941eZVCGtr2dSJAMOclzZGSe+8hnOUnhK4zxa5svxiP6K9O5SMBp3MrAS3WNsRj5hqx6+JHb7iA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-polyfills": "1.7.8",
+        "@reown/appkit-common": "1.8.9",
+        "@reown/appkit-polyfills": "1.8.9",
         "@walletconnect/logger": "2.1.2",
         "zod": "3.22.4"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/types": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
-      "integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "events": "3.3.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -5811,9 +5822,9 @@
       }
     },
     "node_modules/@wagmi/connectors": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-5.11.2.tgz",
-      "integrity": "sha512-OkiElOI8xXGPDZE5UdG6NgDT3laSkEh9llX1DDapUnfnKecK3Tr/HUf5YzgwDhEoox8mdxp+8ZCjtnTKz56SdA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-6.1.1.tgz",
+      "integrity": "sha512-T5orLdX6Kz+UnJxy88aRnlSohnNCkP3KqWI3Hadho2uhFUqA87VWkE6+fD0TI4XA/pDA5wjI2EjCaGTmAxqDtQ==",
       "license": "MIT",
       "dependencies": {
         "@base-org/account": "1.1.1",
@@ -5824,13 +5835,13 @@
         "@safe-global/safe-apps-sdk": "9.1.0",
         "@walletconnect/ethereum-provider": "2.21.1",
         "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3",
-        "porto": "0.2.19"
+        "porto": "0.2.34"
       },
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
       "peerDependencies": {
-        "@wagmi/core": "2.21.2",
+        "@wagmi/core": "2.22.1",
         "typescript": ">=5.0.4",
         "viem": "2.x"
       },
@@ -5841,9 +5852,9 @@
       }
     },
     "node_modules/@wagmi/core": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.21.2.tgz",
-      "integrity": "sha512-Rp4waam2z0FQUDINkJ91jq38PI5wFUHCv1YBL2LXzAQswaEk1ZY8d6+WG3vYGhFHQ22DXy2AlQ8IWmj+2EG3zQ==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
+      "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "5.0.1",
@@ -5896,11 +5907,32 @@
         }
       }
     },
-    "node_modules/@walletconnect/core": {
-      "version": "2.21.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.8.tgz",
-      "integrity": "sha512-MD1SY7KAeHWvufiBK8C1MwP9/pxxI7SnKi/rHYfjco2Xvke+M+Bbm2OzvuSN7dYZvwLTkZCiJmBccTNVPCpSUQ==",
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@walletconnect/core": {
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.22.4.tgz",
+      "integrity": "sha512-ZQnyDDpqDPAk5lyLV19BRccQ3wwK3LmAwibuIv3X+44aT/dOs2kQGu9pla3iW2LgZ5qRMYvgvvfr5g3WlDGceQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -5908,20 +5940,119 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.16",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/logger": "3.0.0",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.8",
-        "@walletconnect/utils": "2.21.8",
+        "@walletconnect/types": "2.22.4",
+        "@walletconnect/utils": "2.22.4",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.39.3",
         "events": "3.3.0",
         "uint8arrays": "3.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/core/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/core/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@walletconnect/environment": {
@@ -5932,22 +6063,122 @@
       }
     },
     "node_modules/@walletconnect/ethereum-provider": {
-      "version": "2.21.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.21.8.tgz",
-      "integrity": "sha512-yjDlPpGMkuSXoIdmX7q7K7mDjPBqBqRW3hjXExhrRpbScdP92ZEFHoJf3E4ALDxdaV894ivXrOmMyGsoY5Eexg==",
-      "license": "Apache-2.0",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.22.4.tgz",
+      "integrity": "sha512-qhBxU95nlndiKGz8lO8z9JlsA4Ai8i1via4VWut2fXsW1fkl6qXG9mYhDRFsbavuynUe3dQ+QLjBVDaaNkcKCA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit": "1.7.8",
+        "@reown/appkit": "1.8.9",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/sign-client": "2.21.8",
-        "@walletconnect/types": "2.21.8",
-        "@walletconnect/universal-provider": "2.21.8",
-        "@walletconnect/utils": "2.21.8",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/sign-client": "2.22.4",
+        "@walletconnect/types": "2.22.4",
+        "@walletconnect/universal-provider": "2.22.4",
+        "@walletconnect/utils": "2.22.4",
         "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@walletconnect/events": {
@@ -6132,6 +6363,8 @@
     },
     "node_modules/@walletconnect/logger": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
@@ -6139,9 +6372,9 @@
       }
     },
     "node_modules/@walletconnect/react-native-compat": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/react-native-compat/-/react-native-compat-2.22.2.tgz",
-      "integrity": "sha512-lLT2fqpjpQHoZYJeif6J+RUL71+bpAQEng52hGSydZo+ntF356ny/C4GkiyICd234x6ilBx55Gf8u7YzQbk7rg==",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/react-native-compat/-/react-native-compat-2.22.4.tgz",
+      "integrity": "sha512-feUNoesD7l+CgxE0MZxqZkf39Ff93fdevnrIstDi0BufaxLLfPuKC+EiVscs4/X9pg/UFp9EIRrCCAtV2dfEcQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "events": "3.3.0",
@@ -6210,20 +6443,119 @@
       }
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.21.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.8.tgz",
-      "integrity": "sha512-lTcUbMjQ0YUZ5wzCLhpBeS9OkWYgLLly6BddEp2+pm4QxiwCCU2Nao0nBJXgzKbZYQOgrEGqtdm/7ze67gjzRA==",
-      "license": "Apache-2.0",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.22.4.tgz",
+      "integrity": "sha512-la+sol0KL33Fyx5DRlupHREIv8wA6W33bRfuLAfLm8pINRTT06j9rz0IHIqJihiALebFxVZNYzJnF65PhV0q3g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@walletconnect/core": "2.21.8",
+        "@walletconnect/core": "2.22.4",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/logger": "3.0.0",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.8",
-        "@walletconnect/utils": "2.21.8",
+        "@walletconnect/types": "2.22.4",
+        "@walletconnect/utils": "2.22.4",
         "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@walletconnect/time": {
@@ -6234,24 +6566,123 @@
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.21.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.8.tgz",
-      "integrity": "sha512-xuLIPrLxe6viMu8Uk28Nf0sgyMy+4oT0mroOjBe5Vqyft8GTiwUBKZXmrGU9uDzZsYVn1FXLO9CkuNHXda3ODA==",
-      "license": "Apache-2.0",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.22.4.tgz",
+      "integrity": "sha512-KJdiS9ezXzx1uASanldYaaenDwb42VOQ6Rj86H7FRwfYddhNnYnyEaDjDKOdToGRGcpt5Uzom6qYUOnrWEbp5g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/logger": "3.0.0",
         "events": "3.3.0"
       }
     },
+    "node_modules/@walletconnect/types/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/types/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/types/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/@walletconnect/universal-provider": {
-      "version": "2.21.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.8.tgz",
-      "integrity": "sha512-Nc1Z6VXnya152yucNDPnlTkrhG289tCUfcjiWqDmwNYzFSfdT5oJQHlnffQXlvoks90kn5Ru8Rnwag2CH1YOVQ==",
-      "license": "Apache-2.0",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.22.4.tgz",
+      "integrity": "sha512-TF2RNX13qxa0rrBAhVDs5+C2G8CHX7L0PH5hF2uyQHdGyxZ3pFbXf8rxmeW1yKlB76FSbW80XXNrUes6eK/xHg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -6259,46 +6690,194 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.21.8",
-        "@walletconnect/types": "2.21.8",
-        "@walletconnect/utils": "2.21.8",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/sign-client": "2.22.4",
+        "@walletconnect/types": "2.22.4",
+        "@walletconnect/utils": "2.22.4",
         "es-toolkit": "1.39.3",
         "events": "3.3.0"
       }
     },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/@walletconnect/utils": {
-      "version": "2.21.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.8.tgz",
-      "integrity": "sha512-HtMraGJ9qXo55l4wGSM1aZvyz0XVv460iWhlRGAyRl9Yz8RQeKyXavDhwBfcTFha/6kwLxPExqQ+MURtKeVVXw==",
-      "license": "Apache-2.0",
+      "version": "2.22.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.22.4.tgz",
+      "integrity": "sha512-coAPrNiTiD+snpiXQyXakMVeYcddqVqII7aLU39TeILdPoXeNPc2MAja+MF7cKNM/PA3tespljvvxck/oTm4+Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@msgpack/msgpack": "3.1.2",
         "@noble/ciphers": "1.3.0",
-        "@noble/curves": "1.9.2",
+        "@noble/curves": "1.9.7",
         "@noble/hashes": "1.8.0",
         "@scure/base": "1.2.6",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.8",
+        "@walletconnect/types": "2.22.4",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "blakejs": "1.2.1",
         "bs58": "6.0.0",
         "detect-browser": "5.3.0",
-        "query-string": "7.1.3",
-        "uint8arrays": "3.1.1",
-        "viem": "2.31.0"
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
       }
     },
-    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -6308,6 +6887,86 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/utils/node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/utils/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@walletconnect/window-getters": {
@@ -6683,6 +7342,8 @@
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -8087,6 +8748,8 @@
     },
     "node_modules/duplexify": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -8100,14 +8763,14 @@
       "license": "MIT"
     },
     "node_modules/eciesjs": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.15.tgz",
-      "integrity": "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.16.tgz",
+      "integrity": "sha512-dS5cbA9rA2VR4Ybuvhg6jvdmp46ubLn3E+px8cG/35aEDNclrqoCjg6mt0HYZ/M+OoESS3jSkCrqk1kWAEhWAw==",
       "license": "MIT",
       "dependencies": {
-        "@ecies/ciphers": "^0.2.3",
+        "@ecies/ciphers": "^0.2.4",
         "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
+        "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0"
       },
       "engines": {
@@ -9637,6 +10300,8 @@
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10237,9 +10902,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.9.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.10.tgz",
-      "integrity": "sha512-AlI15ijFyKTXR7eHo7QK7OR4RoKIedZvBuRjO8iy4zrxvlY5oFCdiRG/V/lFJHCNXJ0k72ATgnyzx8Yqa5arug==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.2.tgz",
+      "integrity": "sha512-p6fyzl+mQo6uhESLxbF5WlBOAJMDh36PljwlKtP5V1v09NxlqGru3ShK+4wKhSuhuYf8qxMmrivHOa/M7q0sMg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -12498,6 +13163,8 @@
     },
     "node_modules/on-exit-leak-free": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -12902,6 +13569,8 @@
     },
     "node_modules/pino": {
       "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -12922,6 +13591,8 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
       "license": "MIT",
       "dependencies": {
         "duplexify": "^4.1.2",
@@ -12930,6 +13601,8 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
       "license": "MIT"
     },
     "node_modules/pirates": {
@@ -12980,12 +13653,12 @@
       }
     },
     "node_modules/porto": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.19.tgz",
-      "integrity": "sha512-q1vEJgdtlEOf6byWgD31GHiMwpfLuxFSfx9f7Sw4RGdvpQs2ANBGfnzzardADZegr87ZXsebSp+3vaaznEUzPQ==",
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.34.tgz",
+      "integrity": "sha512-o+hK9r6a4j3EAFOkgNXtcwYc4vAMsmbVhRJHrBXXV/tGVLb2V2sVGLcCFFH3CLevRAyyUUKoT0KIaoQaro4saA==",
       "license": "MIT",
       "dependencies": {
-        "hono": "^4.9.6",
+        "hono": "^4.10.3",
         "idb-keyval": "^6.2.1",
         "mipd": "^0.0.7",
         "ox": "^0.9.6",
@@ -12993,12 +13666,16 @@
         "zustand": "^5.0.1"
       },
       "bin": {
-        "porto": "_dist/cli/bin/index.js"
+        "porto": "dist/cli/bin/index.js"
       },
       "peerDependencies": {
         "@tanstack/react-query": ">=5.59.0",
         "@wagmi/core": ">=2.16.3",
+        "expo-auth-session": ">=7.0.8",
+        "expo-crypto": ">=15.0.7",
+        "expo-web-browser": ">=15.0.8",
         "react": ">=18",
+        "react-native": ">=0.81.4",
         "typescript": ">=5.4.0",
         "viem": ">=2.37.0",
         "wagmi": ">=2.0.0"
@@ -13007,7 +13684,19 @@
         "@tanstack/react-query": {
           "optional": true
         },
+        "expo-auth-session": {
+          "optional": true
+        },
+        "expo-crypto": {
+          "optional": true
+        },
+        "expo-web-browser": {
+          "optional": true
+        },
         "react": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         },
         "typescript": {
@@ -13139,6 +13828,8 @@
     },
     "node_modules/process-warning": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -13371,6 +14062,8 @@
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/radix3": {
@@ -13814,6 +14507,8 @@
     },
     "node_modules/real-require": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -14204,6 +14899,8 @@
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14571,6 +15268,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
     "node_modules/slugify": {
       "version": "1.6.6",
       "license": "MIT",
@@ -14642,6 +15345,8 @@
     },
     "node_modules/sonic-boom": {
       "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -14687,6 +15392,8 @@
     },
     "node_modules/split2": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -14771,6 +15478,8 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
@@ -15137,6 +15846,8 @@
     },
     "node_modules/thread-stream": {
       "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.1.0"
@@ -15737,9 +16448,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.0.tgz",
-      "integrity": "sha512-YU5TG8dgBNeYPrCMww0u9/JVeq2ZCk9fzk6QybrPkBooFysamHXL1zC3ua10aLPt9iWoA/gSVf1D9w7nc5B1aA==",
+      "version": "2.38.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.5.tgz",
+      "integrity": "sha512-EU2olUnWd5kBK1t3BicwaamPHGUANRYetoDLSVzDy7XQ8o8UswItnkQbufe3xTcdRCtb2JYMwjlgHZZ7fUoLdA==",
       "funding": [
         {
           "type": "github",
@@ -15826,13 +16537,13 @@
       "license": "MIT"
     },
     "node_modules/wagmi": {
-      "version": "2.17.5",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.17.5.tgz",
-      "integrity": "sha512-Sk2e40gfo68gbJ6lHkpIwCMkH76rO0+toCPjf3PzdQX37rZo9042DdNTYcSg3zhnx8abFJtrk/5vAWfR8APTDw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.0.tgz",
+      "integrity": "sha512-0Ypzs5rkj1d6uBcz2PBGqAfk+r2TfsmPh4cMxoCJyFy5P1IL3FHY9lQLCu77NJZ8DlVl+dd9mdPZrQADb8sLcw==",
       "license": "MIT",
       "dependencies": {
-        "@wagmi/connectors": "5.11.2",
-        "@wagmi/core": "2.21.2",
+        "@wagmi/connectors": "6.1.1",
+        "@wagmi/core": "2.22.1",
         "use-sync-external-store": "1.4.0"
       },
       "funding": {

--- a/dapps/appkit-expo-wagmi/package.json
+++ b/dapps/appkit-expo-wagmi/package.json
@@ -23,7 +23,7 @@
     "@reown/appkit-solana-react-native": "2.0.1",
     "@reown/appkit-wagmi-react-native": "2.0.1",
     "@tanstack/react-query": "^5.81.5",
-    "@walletconnect/react-native-compat": "2.22.2",
+    "@walletconnect/react-native-compat": "2.22.4",
     "expo": "54.0.12",
     "expo-application": "~7.0.7",
     "expo-blur": "~15.0.7",
@@ -51,8 +51,8 @@
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.5.1",
     "text-encoding": "0.7.0",
-    "viem": "2.38.0",
-    "wagmi": "2.17.5"
+    "viem": "2.38.5",
+    "wagmi": "2.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -62,11 +62,12 @@
     "typescript": "~5.9.2"
   },
   "overrides": {
-    "@walletconnect/ethereum-provider": "2.21.8",
-    "@walletconnect/universal-provider": "2.21.8",
+    "@walletconnect/ethereum-provider": "2.22.4",
+    "@walletconnect/universal-provider": "2.22.4",
     "valtio": "2.1.8",
-    "viem": "2.38.0",
-    "fast-redact": "3.5.0"
+    "viem": "2.38.5",
+    "fast-redact": "3.5.0",
+    "hono": "4.10.2"
   },
   "private": true
 }

--- a/dapps/pos-app/package-lock.json
+++ b/dapps/pos-app/package-lock.json
@@ -20,7 +20,7 @@
         "@sentry/react-native": "^7.4.0",
         "@tanstack/react-query": "^5.90.5",
         "@walletconnect/pos-client": "0.0.0-canary.3",
-        "@walletconnect/react-native-compat": "^2.22.4",
+        "@walletconnect/react-native-compat": "2.22.4",
         "expo": "~54.0.17",
         "expo-application": "~7.0.7",
         "expo-clipboard": "~8.0.7",
@@ -50,8 +50,8 @@
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
         "text-encoding": "^0.7.0",
-        "viem": "2.38.3",
-        "wagmi": "^2.18.2"
+        "viem": "2.38.5",
+        "wagmi": "2.19.0"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -1574,33 +1574,6 @@
         "preact": "10.24.2",
         "viem": "^2.31.7",
         "zustand": "5.0.3"
-      }
-    },
-    "node_modules/@base-org/account/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@base-org/account/node_modules/@noble/curves/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@base-org/account/node_modules/@noble/hashes": {
@@ -6735,9 +6708,9 @@
       }
     },
     "node_modules/@wagmi/connectors": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-6.1.0.tgz",
-      "integrity": "sha512-MnpJHEABUIsajNxLc6br0LiqJvoFZbavQ6yG+mQb7Xlb3Hmm3IRjH5NU1g2zw5PCTRd3BFQLjwniLdwDnUPYNw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-6.1.1.tgz",
+      "integrity": "sha512-T5orLdX6Kz+UnJxy88aRnlSohnNCkP3KqWI3Hadho2uhFUqA87VWkE6+fD0TI4XA/pDA5wjI2EjCaGTmAxqDtQ==",
       "license": "MIT",
       "dependencies": {
         "@base-org/account": "1.1.1",
@@ -6748,7 +6721,7 @@
         "@safe-global/safe-apps-sdk": "9.1.0",
         "@walletconnect/ethereum-provider": "2.21.1",
         "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3",
-        "porto": "0.2.19"
+        "porto": "0.2.34"
       },
       "funding": {
         "url": "https://github.com/sponsors/wevm"
@@ -6762,132 +6735,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/abitype": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.1.tgz",
-      "integrity": "sha512-Loe5/6tAgsBukY95eGaPSDmQHIjRZYQq8PB1MpsNccDIK8WiV+Uw6WzaIXipvaxTEL2yEB0OpEaQv3gs8pkS9Q==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3.22.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/ox": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.12.tgz",
-      "integrity": "sha512-esyA5WXfFhlxpgzoVIEreRaasqqv95sjFpk3L4Me4RWk8bgBDe+J4wO3RZ5ikYmJ2Bbjyv+jKgxyaOzX6JpHPA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.9",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/porto": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.19.tgz",
-      "integrity": "sha512-q1vEJgdtlEOf6byWgD31GHiMwpfLuxFSfx9f7Sw4RGdvpQs2ANBGfnzzardADZegr87ZXsebSp+3vaaznEUzPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "hono": "^4.9.6",
-        "idb-keyval": "^6.2.1",
-        "mipd": "^0.0.7",
-        "ox": "^0.9.6",
-        "zod": "^4.1.5",
-        "zustand": "^5.0.1"
-      },
-      "bin": {
-        "porto": "_dist/cli/bin/index.js"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": ">=5.59.0",
-        "@wagmi/core": ">=2.16.3",
-        "react": ">=18",
-        "typescript": ">=5.4.0",
-        "viem": ">=2.37.0",
-        "wagmi": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@tanstack/react-query": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "wagmi": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@wagmi/core": {
@@ -15095,6 +14942,70 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/porto": {
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.34.tgz",
+      "integrity": "sha512-o+hK9r6a4j3EAFOkgNXtcwYc4vAMsmbVhRJHrBXXV/tGVLb2V2sVGLcCFFH3CLevRAyyUUKoT0KIaoQaro4saA==",
+      "license": "MIT",
+      "dependencies": {
+        "hono": "^4.10.3",
+        "idb-keyval": "^6.2.1",
+        "mipd": "^0.0.7",
+        "ox": "^0.9.6",
+        "zod": "^4.1.5",
+        "zustand": "^5.0.1"
+      },
+      "bin": {
+        "porto": "dist/cli/bin/index.js"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": ">=5.59.0",
+        "@wagmi/core": ">=2.16.3",
+        "expo-auth-session": ">=7.0.8",
+        "expo-crypto": ">=15.0.7",
+        "expo-web-browser": ">=15.0.8",
+        "react": ">=18",
+        "react-native": ">=0.81.4",
+        "typescript": ">=5.4.0",
+        "viem": ">=2.37.0",
+        "wagmi": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+          "optional": true
+        },
+        "expo-auth-session": {
+          "optional": true
+        },
+        "expo-crypto": {
+          "optional": true
+        },
+        "expo-web-browser": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "wagmi": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/porto/node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -18663,9 +18574,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.38.3",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.3.tgz",
-      "integrity": "sha512-By2TutLv07iNHHtWqHHzjGipevYsfGqT7KQbGEmqLco1qTJxKnvBbSviqiu6/v/9REV6Q/FpmIxf2Z7/l5AbcQ==",
+      "version": "2.38.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.5.tgz",
+      "integrity": "sha512-EU2olUnWd5kBK1t3BicwaamPHGUANRYetoDLSVzDy7XQ8o8UswItnkQbufe3xTcdRCtb2JYMwjlgHZZ7fUoLdA==",
       "funding": [
         {
           "type": "github",
@@ -18747,12 +18658,12 @@
       "license": "MIT"
     },
     "node_modules/wagmi": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.18.2.tgz",
-      "integrity": "sha512-9jFip+0ZfjMBxT72m02MZD2+VmQQ/UmqZhHl+98N9HEqXLn765fIu45QPV85DAnQqIHD81gvY3vTvfWt16A5yQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.0.tgz",
+      "integrity": "sha512-0Ypzs5rkj1d6uBcz2PBGqAfk+r2TfsmPh4cMxoCJyFy5P1IL3FHY9lQLCu77NJZ8DlVl+dd9mdPZrQADb8sLcw==",
       "license": "MIT",
       "dependencies": {
-        "@wagmi/connectors": "6.1.0",
+        "@wagmi/connectors": "6.1.1",
         "@wagmi/core": "2.22.1",
         "use-sync-external-store": "1.4.0"
       },

--- a/dapps/pos-app/package.json
+++ b/dapps/pos-app/package.json
@@ -25,7 +25,7 @@
     "@sentry/react-native": "^7.4.0",
     "@tanstack/react-query": "^5.90.5",
     "@walletconnect/pos-client": "0.0.0-canary.3",
-    "@walletconnect/react-native-compat": "^2.22.4",
+    "@walletconnect/react-native-compat": "2.22.4",
     "expo": "~54.0.17",
     "expo-application": "~7.0.7",
     "expo-clipboard": "~8.0.7",
@@ -55,8 +55,8 @@
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
     "text-encoding": "^0.7.0",
-    "viem": "2.38.3",
-    "wagmi": "^2.18.2"
+    "viem": "2.38.5",
+    "wagmi": "2.19.0"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
@@ -68,13 +68,14 @@
     "typescript": "~5.9.2"
   },
   "overrides": {
-    "viem": "2.38.3",
+    "viem": "2.38.5",
     "@walletconnect/universal-provider": "2.22.4",
     "@walletconnect/core": "2.22.4",
     "@walletconnect/logger": "2.1.2",
     "@walletconnect/sign-client": "2.22.4",
     "@walletconnect/types": "2.22.4",
-    "@walletconnect/utils": "2.22.4"
+    "@walletconnect/utils": "2.22.4",
+    "hono": "4.10.2"
   },
   "private": true
 }


### PR DESCRIPTION
**Dependency Updates:**

* Upgraded `wagmi` to `2.19.0` and `viem` to `2.38.5` across `dapps/W3MWagmi`, `dapps/appkit-expo-wagmi`, and `dapps/pos-app` to keep in sync with the latest releases. [[1]](diffhunk://#diff-8aeb884ea037e71fc572eab17fcbaabc731e87c54115d6980178156a43b51174L53-R54) [[2]](diffhunk://#diff-848e7b446b7a87c7ce4c6f0a5270513781af70e09874aab651bb702b59015373L54-R55) [[3]](diffhunk://#diff-2a975773663611129b1206807223337b581e83ed890121f506d4e8f4f17ce197L53-R54) [[4]](diffhunk://#diff-2a975773663611129b1206807223337b581e83ed890121f506d4e8f4f17ce197L18666-R18579) [[5]](diffhunk://#diff-2a975773663611129b1206807223337b581e83ed890121f506d4e8f4f17ce197L18750-R18666) [[6]](diffhunk://#diff-ce0ed72aaca5a18ad4f7f6999afc197c9dc05173c895d63b9473c85b7c6d1c50L58-R59)
* Updated `@walletconnect` packages (`ethereum-provider`, `universal-provider`, `react-native-compat`) to `2.22.4` for better compatibility and bug fixes in all relevant dapps. [[1]](diffhunk://#diff-8aeb884ea037e71fc572eab17fcbaabc731e87c54115d6980178156a43b51174L98-R105) [[2]](diffhunk://#diff-848e7b446b7a87c7ce4c6f0a5270513781af70e09874aab651bb702b59015373L26-R26) [[3]](diffhunk://#diff-848e7b446b7a87c7ce4c6f0a5270513781af70e09874aab651bb702b59015373L65-R70) [[4]](diffhunk://#diff-2a975773663611129b1206807223337b581e83ed890121f506d4e8f4f17ce197L23-R23)
* Updated `@wagmi/connectors` to `6.1.1` and related dependencies in the POS app for improved connector support. [[1]](diffhunk://#diff-2a975773663611129b1206807223337b581e83ed890121f506d4e8f4f17ce197L6738-R6713) [[2]](diffhunk://#diff-2a975773663611129b1206807223337b581e83ed890121f506d4e8f4f17ce197L18750-R18666)

**New and Upgraded Packages:**

* Added `hono` version `4.10.2` as a new dependency and override in all three dapps
