### PR TITLE
fix: strip scientific notation suffix from cast output in balance check

### DIFF
--- a/.github/workflows/e2e-balance-check.yml
+++ b/.github/workflows/e2e-balance-check.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           BALANCE=$(cast call --rpc-url "$BASE_RPC" "$BASE_USDC" \
             "balanceOf(address)(uint256)" \
-            "${{ vars.TEST_WALLET_ADDRESS }}" | tr -d '[:space:]')
+            "${{ vars.TEST_WALLET_ADDRESS }}" | sed 's/\[.*\]//' | tr -d '[:space:]')
           echo "balance=$BALANCE" >> $GITHUB_OUTPUT
           BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
           echo "USDC on Base: $BALANCE_HUMAN ($BALANCE raw)"
@@ -74,7 +74,7 @@ jobs:
         run: |
           BALANCE=$(cast call --rpc-url "$OP_RPC" "$OP_USDC" \
             "balanceOf(address)(uint256)" \
-            "${{ vars.TEST_WALLET_ADDRESS }}" | tr -d '[:space:]')
+            "${{ vars.TEST_WALLET_ADDRESS }}" | sed 's/\[.*\]//' | tr -d '[:space:]')
           echo "balance=$BALANCE" >> $GITHUB_OUTPUT
           BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
           echo "USDC on Optimism: $BALANCE_HUMAN ($BALANCE raw)"


### PR DESCRIPTION
## Summary

- Newer Foundry `cast call` returns values with a scientific notation suffix (e.g. `240000[2.4e5]` instead of `240000`)
- This broke the `e2e-balance-check` workflow — `bc` threw syntax errors and bash `-lt` comparisons failed with `integer expression expected`
- Adds `sed 's/\[.*\]//'` to strip the bracket suffix before whitespace removal, fixing both Base and Optimism balance checks

## How it works

```mermaid
flowchart LR
    A["cast call output\n240000[2.4e5]"] --> B["sed strips brackets\n240000"]
    B --> C["tr strips whitespace\n240000"]
    C --> D["bc / bash work correctly"]
```

## Test plan

- [x] Trigger `E2E Wallet Balance Check` workflow manually via `workflow_dispatch`
- [x] Confirm no `syntax error` from `bc`
- [x] Confirm no `integer expression expected` from bash comparisons
- [x] Verify Slack alerts fire correctly when balance is below threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)