### PR TITLE
[codex] Fix iOS WalletKit Maestro diagnostics

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -438,10 +438,10 @@ runs:
             --predicate "process == \"$APP_PROCESS_NAME\" OR sender == \"$APP_PROCESS_NAME\" OR processImagePath CONTAINS[c] \"/$APP_PROCESS_NAME.app/\" OR senderImagePath CONTAINS[c] \"/$APP_PROCESS_NAME.app/\" OR eventMessage CONTAINS[c] \"$APP_ID\"" \
             --last 5m \
             > ios-diagnostics/sim-app.log 2>&1 || true
-          xcrun simctl spawn "$DEVICE_ID" log show \
-            --last 5m \
-            > ios-diagnostics/sim-device.log 2>&1 || true
-          xcrun simctl diagnose -b --no-archive --output=ios-diagnostics/simctl-diagnose --udid "$DEVICE_ID" || true
+          # Redact 64-char hex strings (private-key shape) before upload.
+          sed -E 's/[0-9a-fA-F]{64}/[REDACTED]/g' ios-diagnostics/sim-app.log \
+            > ios-diagnostics/sim-app.log.tmp \
+            && mv ios-diagnostics/sim-app.log.tmp ios-diagnostics/sim-app.log
         fi
         ls -la ios-diagnostics || true
 

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -403,7 +403,7 @@ runs:
         WPAY_PAY_API_URL: ${{ inputs.pay-api-url }}
         WPAY_EXPIRED_GATEWAY_URL: ${{ inputs.expired-gateway-url }}
       run: |
-        xcrun simctl launch "$DEVICE_ID" "$APP_ID" || true
+        xcrun simctl bootstatus "$DEVICE_ID" -b
         set +e
         $HOME/.maestro/bin/maestro test \
           --env APP_ID="$APP_ID" \
@@ -424,6 +424,27 @@ runs:
         cat maestro-output.log
         exit "$maestro_exit_code"
 
+    - name: Collect iOS diagnostics
+      if: always() && inputs.platform == 'ios'
+      shell: bash
+      env:
+        APP_ID: com.walletconnect.web3wallet.rnsample.internal
+        APP_PROCESS_NAME: RNWallet Internal
+      run: |
+        mkdir -p ios-diagnostics/DiagnosticReports
+        cp -R "$HOME/Library/Logs/DiagnosticReports/." ios-diagnostics/DiagnosticReports/ 2>/dev/null || true
+        if [ -n "${DEVICE_ID:-}" ]; then
+          xcrun simctl spawn "$DEVICE_ID" log show \
+            --predicate "process == \"$APP_PROCESS_NAME\" OR sender == \"$APP_PROCESS_NAME\" OR processImagePath CONTAINS[c] \"/$APP_PROCESS_NAME.app/\" OR senderImagePath CONTAINS[c] \"/$APP_PROCESS_NAME.app/\" OR eventMessage CONTAINS[c] \"$APP_ID\"" \
+            --last 5m \
+            > ios-diagnostics/sim-app.log 2>&1 || true
+          xcrun simctl spawn "$DEVICE_ID" log show \
+            --last 5m \
+            > ios-diagnostics/sim-device.log 2>&1 || true
+          xcrun simctl diagnose -b --no-archive --output=ios-diagnostics/simctl-diagnose --udid "$DEVICE_ID" || true
+        fi
+        ls -la ios-diagnostics || true
+
     - name: Upload Maestro artifacts (iOS)
       if: always() && inputs.platform == 'ios'
       uses: actions/upload-artifact@v4
@@ -438,6 +459,7 @@ runs:
           maestro-artifacts/**/*.webm
           maestro-artifacts/**/*.gif
           maestro-output.log
+          ios-diagnostics/**
         if-no-files-found: warn
         retention-days: 14
 


### PR DESCRIPTION
## Summary
- replace the iOS `simctl launch` pre-launch with `simctl bootstatus` so Maestro owns app startup
- collect crash reports, app logs, device logs, and scoped `simctl diagnose` output after each iOS Maestro run
- filter app logs by the actual `RNWallet Internal` process so the diagnostic artifact captures the wallet process reliably

## Why
This makes the flaky `pay_cancelled` flow diagnosable and removes the extra launch/relaunch race during cold start.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/walletkit-build-and-maestro/action.yml"); puts "YAML OK"'`

```mermaid
flowchart LR
  A[Boot simulator] --> B[Maestro launches app]
  B --> C[Collect crash reports and simulator logs]
  C --> D[Upload iOS diagnostics artifact]
```