### PR TITLE
fix(wallet): include broadcast tx hash in WCPay signatures

### DIFF
--- a/wallets/rn_cli_wallet/src/store/PaymentStore.ts
+++ b/wallets/rn_cli_wallet/src/store/PaymentStore.ts
@@ -556,6 +556,7 @@ const PaymentStore = {
               'approvePayment',
               { chainId, step: stepLabel, txHash: tx.hash },
             );
+            signatures.push(tx.hash);
             break;
           }
 


### PR DESCRIPTION
## Summary

- Native ETH payments via WCPay (e.g., ETH on Base) produce a single `eth_sendTransaction` action. The wallet broadcasts that tx itself, waits for confirmation, then calls `confirmPayment` — but the broadcast tx hash was never added to `signatures`, so the array was empty.
- The yttrium-wcpay backend rejects this with `400: Validation error: Next result not present`, because its result chain expects one entry per required action.
- Fix: append `tx.hash` to `signatures` after `waitForTransactionConfirmation`, so `signatures.length === paymentActions.length` and per-action order is preserved.
- Mirrors [reown-kotlin#380](https://github.com/reown-com/reown-kotlin/pull/380).

## Action → signature mapping after this change

```mermaid
flowchart LR
    A[paymentActions] --> B{action.walletRpc.method}
    B -->|eth_sendTransaction| C[sendTransactionWithFreshFees + waitForTransactionConfirmation]
    C --> D[signatures.push&#40;tx.hash&#41;]
    B -->|eth_signTypedData_*| E[wallet._signTypedData]
    E --> F[signatures.push&#40;signature&#41;]
    D --> G[payClient.confirmPayment&#40;{ signatures }&#41;]
    F --> G
```

## Test plan

- [ ] Native ETH payment on Base completes successfully (was failing with `400: Validation error: Next result not present`)
- [ ] USDC payment on Base/OP/Polygon/Mainnet with first-time approval still completes — approval `eth_sendTransaction` followed by typed-data signature both reach the backend in order
- [ ] USDC payment with no approval required still completes
- [ ] Confirm `Action transaction confirmed` log appears before `Confirming payment` in `LogStore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)