### PR TITLE
ci(walletkit): prime Universal Link AASA + widen iOS syslog predicate

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -290,6 +290,17 @@ runs:
       shell: bash
       run: xcrun simctl install "$DEVICE_ID" "$APP_PATH"
 
+    - name: Prime Universal Link AASA cache
+      if: inputs.platform == 'ios'
+      shell: bash
+      run: |
+        xcrun simctl spawn "$DEVICE_ID" swcutil reset || true
+        for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com; do
+          xcrun simctl spawn "$DEVICE_ID" swcutil dl -d "$domain" || true
+        done
+        sleep 3
+        xcrun simctl spawn "$DEVICE_ID" swcutil show 2>/dev/null | grep -i walletconnect || true
+
     # --- Android leg ---
     - name: Install Java 17
       if: inputs.platform == 'android'
@@ -408,7 +419,7 @@ runs:
         xcrun simctl spawn "$DEVICE_ID" log stream \
           --level=debug \
           --style=compact \
-          --predicate "process == \"RNWallet-Internal\" OR senderImagePath CONTAINS \"RNWallet\"" \
+          --predicate "process == \"RNWallet-Internal\" OR senderImagePath CONTAINS \"RNWallet\" OR process CONTAINS \"maestro\" OR process == \"xctest\" OR process == \"testmanagerd\" OR process == \"tccd\" OR process == \"SpringBoard\"" \
           > maestro-artifacts/ios-syslog.log 2>&1 &
         SYSLOG_PID=$!
         set +e

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -73,7 +73,7 @@ inputs:
   maestro-actions-ref:
     description: 'Pinned ref of WalletConnect/actions for maestro/pay-tests and maestro/setup.'
     required: false
-    default: 'e055fc0dffe1b83e08629c22be7038b298c4416e'
+    default: 'afc741fbe638ca13cfc10de2ed59b064c2b59436'
   apple-key-id:
     description: 'Apple App Store Connect API key id (iOS only).'
     required: false
@@ -392,10 +392,10 @@ runs:
 
     # --- Common: Maestro setup + run ---
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@e055fc0dffe1b83e08629c22be7038b298c4416e
+      uses: WalletConnect/actions/maestro/pay-tests@afc741fbe638ca13cfc10de2ed59b064c2b59436
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@e055fc0dffe1b83e08629c22be7038b298c4416e
+      uses: WalletConnect/actions/maestro/setup@afc741fbe638ca13cfc10de2ed59b064c2b59436
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'


### PR DESCRIPTION
## Summary

Addresses two intermittent failures in the iOS Maestro pay E2E job:

1. **Deeplink test sometimes opens Safari instead of the wallet.** The pay deeplink flow opens an HTTPS URL on `pay.walletconnect.com` — a Universal Link. After `simctl install`, iOS schedules the AASA fetch asynchronously, so if Maestro fires the deeplink before `swcd` has registered the association, iOS falls back to Safari. The fix force-fetches the AASA for `pay.walletconnect.com`, `staging.pay.walletconnect.com`, and `dev.pay.walletconnect.com` via `swcutil dl` right after install, then prints `swcutil show` for diagnostics. Wallet entitlements already declare these `applinks:` — this just makes the registration synchronous.

2. **`Failed to connect to /127.0.0.1:7001` cascade.** When the Maestro XCTest runner dies mid-run, every subsequent flow's `clearState` fails. The previous syslog predicate only matched `RNWallet*`, so the runner's lifecycle was invisible. Widened it to also include `maestro`, `xctest`, `testmanagerd`, `tccd`, and `SpringBoard` so the next failure leaves enough breadcrumbs to identify the killer.

This is observability + a targeted preflight; no app-side changes.

## Flow

```mermaid
flowchart TD
    A[simctl create / boot] --> B[simctl install wallet]
    B --> C{New: swcutil reset + dl<br/>pay.walletconnect.com<br/>staging.pay.walletconnect.com<br/>dev.pay.walletconnect.com}
    C --> D[Maestro test run]
    D -->|openLink HTTPS gateway URL| E{AASA registered?}
    E -->|Yes ✅| F[Wallet app opens]
    E -->|No ❌ before fix| G[Safari opens → test fails]
    D --> H[log stream — now also captures<br/>maestro/xctest/testmanagerd/tccd/SpringBoard]
```

## Test plan

- [ ] Re-run the failing scheduled E2E iOS workflow and confirm `WalletConnect Pay - Single Option No KYC (Deep Link)` passes.
- [ ] Inspect `maestro-artifacts/ios-syslog.log` from a run and verify it now contains `xctest` / `testmanagerd` lines around test boundaries.
- [ ] If the `:7001` cascade reappears, grab the syslog and look for the runner exit cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)