### PR TITLE
feat(rn_cli_wallet): add Solana support in WalletConnect Pay

### DIFF
--- a/wallets/rn_cli_wallet/__tests__/PaymentStore.test.ts
+++ b/wallets/rn_cli_wallet/__tests__/PaymentStore.test.ts
@@ -16,11 +16,13 @@ jest.mock('../src/store/LogStore', () => ({
   ),
 }));
 
+const mockedSolanaSignTransaction = jest.fn();
 jest.mock('../src/store/SettingsStore', () => ({
   __esModule: true,
   default: {
     state: {
       eip155Address: '0xabc',
+      solanaWallet: { signTransaction: mockedSolanaSignTransaction },
     },
   },
 }));
@@ -62,7 +64,9 @@ jest.mock('../src/utils/storage', () => ({
 }));
 
 import PaymentStore from '../src/store/PaymentStore';
+import SettingsStore from '../src/store/SettingsStore';
 import { EIP155_SIGNING_METHODS } from '../src/constants/Eip155';
+import { SOLANA_SIGNING_METHODS } from '../src/constants/Solana';
 import { walletKit } from '../src/utils/WalletKitUtil';
 import { eip155Wallets } from '../src/utils/EIP155WalletUtil';
 import { storage } from '../src/utils/storage';
@@ -93,6 +97,21 @@ function createAction(method: string, params: unknown[] = []): Action {
   return {
     walletRpc: {
       chainId: 'eip155:137',
+      method,
+      params: JSON.stringify(params),
+    },
+  };
+}
+
+const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+function createSolanaAction(
+  method: string,
+  params: Record<string, unknown> | unknown[],
+): Action {
+  return {
+    walletRpc: {
+      chainId: SOLANA_CHAIN_ID,
       method,
       params: JSON.stringify(params),
     },
@@ -198,6 +217,13 @@ describe('PaymentStore', () => {
     } as any);
     mockedWaitForTransactionConfirmation.mockResolvedValue(undefined);
     mockedSignTypedData.mockResolvedValue('0xsigned');
+    mockedSolanaSignTransaction.mockResolvedValue({
+      transaction: 'signed-b64',
+      signature: 'sol-sig-1',
+    });
+    (SettingsStore.state as any).solanaWallet = {
+      signTransaction: mockedSolanaSignTransaction,
+    };
     mockedStorageGetItem.mockResolvedValue(undefined);
     mockedStorageSetItem.mockResolvedValue(undefined as any);
     mockedStorageRemoveItem.mockResolvedValue(undefined as any);
@@ -667,5 +693,103 @@ describe('PaymentStore', () => {
       'caip19/eip155:137/erc20:0x1',
     );
     expect(PaymentStore.state.resultStatus).toBe('success');
+  });
+
+  it('signs and forwards the signed blob for Solana payment actions (array-wrapped params)', async () => {
+    mockedGetRequiredPaymentActions.mockResolvedValue([
+      createSolanaAction(SOLANA_SIGNING_METHODS.SOLANA_SIGN_TRANSACTION, [
+        { transaction: 'unsigned-b64' },
+      ]),
+    ]);
+
+    const paymentOptions = createPaymentOptions([
+      {
+        id: 'solana-option',
+        account: `${SOLANA_CHAIN_ID}:SoLPubKey`,
+        amount: {
+          unit: `caip19/${SOLANA_CHAIN_ID}/slip44:501`,
+          value: '1000000',
+          display: {
+            assetSymbol: 'SOL',
+            assetName: 'Solana',
+            decimals: 9,
+            networkName: 'Solana',
+            iconUrl: 'https://example.com/sol.png',
+            networkIconUrl: 'https://example.com/solana.png',
+          },
+        } as PaymentOption['amount'],
+        actions: [],
+      },
+    ]);
+
+    PaymentStore.setPaymentOptions(paymentOptions);
+    PaymentStore.selectOption(paymentOptions.options[0]);
+
+    await flushPromises();
+    await PaymentStore.approvePayment();
+
+    expect(mockedSolanaSignTransaction).toHaveBeenCalledWith({
+      transaction: 'unsigned-b64',
+    });
+    expect(mockedConfirmPayment).toHaveBeenCalledWith({
+      paymentId: 'payment-1',
+      optionId: 'solana-option',
+      signatures: ['signed-b64'],
+    });
+    expect(PaymentStore.state.resultStatus).toBe('success');
+  });
+
+  it('also accepts Solana params as a bare object (forward compat)', async () => {
+    mockedGetRequiredPaymentActions.mockResolvedValue([
+      createSolanaAction(SOLANA_SIGNING_METHODS.SOLANA_SIGN_TRANSACTION, {
+        transaction: 'unsigned-b64',
+      }),
+    ]);
+
+    const paymentOptions = createPaymentOptions([
+      {
+        id: 'solana-option',
+        account: `${SOLANA_CHAIN_ID}:SoLPubKey`,
+        actions: [],
+      },
+    ]);
+
+    PaymentStore.setPaymentOptions(paymentOptions);
+    PaymentStore.selectOption(paymentOptions.options[0]);
+
+    await flushPromises();
+    await PaymentStore.approvePayment();
+
+    expect(mockedSolanaSignTransaction).toHaveBeenCalledWith({
+      transaction: 'unsigned-b64',
+    });
+    expect(PaymentStore.state.resultStatus).toBe('success');
+  });
+
+  it('surfaces an error when the Solana wallet is not initialized', async () => {
+    (SettingsStore.state as any).solanaWallet = null;
+    mockedGetRequiredPaymentActions.mockResolvedValue([
+      createSolanaAction(SOLANA_SIGNING_METHODS.SOLANA_SIGN_TRANSACTION, [
+        { transaction: 'unsigned-b64' },
+      ]),
+    ]);
+
+    const paymentOptions = createPaymentOptions([
+      {
+        id: 'solana-option',
+        account: `${SOLANA_CHAIN_ID}:SoLPubKey`,
+        actions: [],
+      },
+    ]);
+
+    PaymentStore.setPaymentOptions(paymentOptions);
+    PaymentStore.selectOption(paymentOptions.options[0]);
+
+    await flushPromises();
+    await PaymentStore.approvePayment();
+
+    expect(mockedSolanaSignTransaction).not.toHaveBeenCalled();
+    expect(mockedConfirmPayment).not.toHaveBeenCalled();
+    expect(PaymentStore.state.resultStatus).toBe('error');
   });
 });

--- a/wallets/rn_cli_wallet/android/app/build.gradle
+++ b/wallets/rn_cli_wallet/android/app/build.gradle
@@ -85,7 +85,7 @@ android {
         applicationId "com.walletconnect.web3wallet.rnsample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 65
+        versionCode 66
         versionName "1.0"
         resValue "string", "build_config_package", "com.walletconnect.web3wallet.rnsample"
     }

--- a/wallets/rn_cli_wallet/src/hooks/usePairing.ts
+++ b/wallets/rn_cli_wallet/src/hooks/usePairing.ts
@@ -6,6 +6,7 @@ import ModalStore from '@/store/ModalStore';
 import SettingsStore from '@/store/SettingsStore';
 import PaymentStore from '@/store/PaymentStore';
 import { EIP155_CHAINS } from '@/constants/Eip155';
+import { SOLANA_CHAINS } from '@/constants/Solana';
 
 export { isPaymentLink };
 
@@ -26,11 +27,19 @@ export function usePairing() {
 
     try {
       const eip155Address = SettingsStore.state.eip155Address;
-      const accounts = eip155Address
-        ? Object.keys(EIP155_CHAINS).map(
-            chainKey => `${chainKey}:${eip155Address}`,
-          )
-        : [];
+      const solanaAddress = SettingsStore.state.solanaAddress;
+      const accounts = [
+        ...(eip155Address
+          ? Object.keys(EIP155_CHAINS).map(
+              chainKey => `${chainKey}:${eip155Address}`,
+            )
+          : []),
+        ...(solanaAddress
+          ? Object.keys(SOLANA_CHAINS).map(
+              chainKey => `${chainKey}:${solanaAddress}`,
+            )
+          : []),
+      ];
 
       const paymentOptions = await payClient.getPaymentOptions({
         paymentLink,

--- a/wallets/rn_cli_wallet/src/store/PaymentStore.ts
+++ b/wallets/rn_cli_wallet/src/store/PaymentStore.ts
@@ -602,6 +602,11 @@ const PaymentStore = {
 
         switch (method) {
           case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION: {
+            if (!evmWallet) {
+              throw new Error(
+                `${method} requires an eip155 chainId, got ${chainId}`,
+              );
+            }
             const arrayParams = requireArrayParams();
             const txPayload = arrayParams[0];
             if (!txPayload || typeof txPayload !== 'object') {
@@ -613,7 +618,7 @@ const PaymentStore = {
             const tx = await sendTransactionWithFreshFees({
               chainId,
               baseTx: { ...(txPayload as providers.TransactionRequest) },
-              wallet: evmWallet!,
+              wallet: evmWallet,
               logContext: 'approvePayment',
             });
 
@@ -647,6 +652,11 @@ const PaymentStore = {
           case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA:
           case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3:
           case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4: {
+            if (!evmWallet) {
+              throw new Error(
+                `${method} requires an eip155 chainId, got ${chainId}`,
+              );
+            }
             const arrayParams = requireArrayParams();
             let typedData: unknown = arrayParams[1];
             try {
@@ -683,7 +693,7 @@ const PaymentStore = {
             }
 
             delete types.EIP712Domain;
-            const signature = await evmWallet!._signTypedData(
+            const signature = await evmWallet._signTypedData(
               domain,
               types,
               messageData,
@@ -693,6 +703,11 @@ const PaymentStore = {
           }
 
           case SOLANA_SIGNING_METHODS.SOLANA_SIGN_TRANSACTION: {
+            if (!solanaWallet) {
+              throw new Error(
+                `${method} requires a solana chainId, got ${chainId}`,
+              );
+            }
             // Pay backend may serialize params as either a bare object
             // ({ transaction }) or wrapped in a single-element array
             // ([{ transaction }]); unwrap the array form transparently.
@@ -716,7 +731,7 @@ const PaymentStore = {
               );
             }
             const { transaction: signedTransaction, signature } =
-              await solanaWallet!.signTransaction({
+              await solanaWallet.signTransaction({
                 transaction: transactionParam,
               });
             LogStore.log(

--- a/wallets/rn_cli_wallet/src/store/PaymentStore.ts
+++ b/wallets/rn_cli_wallet/src/store/PaymentStore.ts
@@ -20,6 +20,8 @@ import {
 } from '@/modals/PaymentOptionsModal/utils';
 import type { ErrorType } from '@/modals/PaymentOptionsModal/utils';
 import { EIP155_SIGNING_METHODS } from '@/constants/Eip155';
+import { SOLANA_SIGNING_METHODS } from '@/constants/Solana';
+import type SolanaLib from '@/lib/SolanaLib';
 import {
   estimateTransactionFee,
   sendTransactionWithFreshFees,
@@ -510,11 +512,6 @@ const PaymentStore = {
         throw new Error('Pay SDK not available');
       }
 
-      const wallet = eip155Wallets[SettingsStore.state.eip155Address];
-      if (!wallet) {
-        throw new Error('Wallet not found for selected EIP155 account');
-      }
-
       const signatures: string[] = [];
       const paymentActions = await PaymentStore.fetchPaymentActions(
         selectedOption,
@@ -565,15 +562,48 @@ const PaymentStore = {
           );
         }
 
-        if (!Array.isArray(parsedParams)) {
-          throw new Error(
-            `Invalid params for ${method} (${stepLabel}): expected array`,
-          );
+        const requireArrayParams = () => {
+          if (!Array.isArray(parsedParams)) {
+            throw new Error(
+              `Invalid params for ${method} (${stepLabel}): expected array`,
+            );
+          }
+          return parsedParams as unknown[];
+        };
+
+        const namespace = chainId.split(':')[0];
+        let evmWallet:
+          | (typeof eip155Wallets)[keyof typeof eip155Wallets]
+          | undefined;
+        let solanaWallet: SolanaLib | undefined;
+
+        switch (namespace) {
+          case 'eip155': {
+            const stored = eip155Wallets[SettingsStore.state.eip155Address];
+            if (!stored) {
+              throw new Error('EIP155 wallet not found for selected account');
+            }
+            evmWallet = stored;
+            break;
+          }
+          case 'solana': {
+            const stored = SettingsStore.state.solanaWallet;
+            if (!stored) {
+              throw new Error('Solana wallet not initialized');
+            }
+            solanaWallet = stored;
+            break;
+          }
+          default:
+            throw new Error(
+              `Unsupported payment chain namespace: ${namespace} (chainId=${chainId})`,
+            );
         }
 
         switch (method) {
           case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION: {
-            const txPayload = parsedParams[0];
+            const arrayParams = requireArrayParams();
+            const txPayload = arrayParams[0];
             if (!txPayload || typeof txPayload !== 'object') {
               throw new Error(
                 `Invalid tx payload for ${method} (${stepLabel})`,
@@ -583,7 +613,7 @@ const PaymentStore = {
             const tx = await sendTransactionWithFreshFees({
               chainId,
               baseTx: { ...(txPayload as providers.TransactionRequest) },
-              wallet,
+              wallet: evmWallet!,
               logContext: 'approvePayment',
             });
 
@@ -617,7 +647,8 @@ const PaymentStore = {
           case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA:
           case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3:
           case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4: {
-            let typedData: unknown = parsedParams[1];
+            const arrayParams = requireArrayParams();
+            let typedData: unknown = arrayParams[1];
             try {
               if (typeof typedData === 'string')
                 typedData = JSON.parse(typedData);
@@ -652,12 +683,49 @@ const PaymentStore = {
             }
 
             delete types.EIP712Domain;
-            const signature = await wallet._signTypedData(
+            const signature = await evmWallet!._signTypedData(
               domain,
               types,
               messageData,
             );
             signatures.push(signature);
+            break;
+          }
+
+          case SOLANA_SIGNING_METHODS.SOLANA_SIGN_TRANSACTION: {
+            // Pay backend may serialize params as either a bare object
+            // ({ transaction }) or wrapped in a single-element array
+            // ([{ transaction }]); unwrap the array form transparently.
+            const rawParams = Array.isArray(parsedParams)
+              ? parsedParams[0]
+              : parsedParams;
+            if (
+              !rawParams ||
+              typeof rawParams !== 'object' ||
+              Array.isArray(rawParams)
+            ) {
+              throw new Error(
+                `Invalid params for ${method} (${stepLabel}): expected object`,
+              );
+            }
+            const transactionParam = (rawParams as Record<string, unknown>)
+              .transaction;
+            if (typeof transactionParam !== 'string') {
+              throw new Error(
+                `Invalid Solana transaction param for ${method} (${stepLabel})`,
+              );
+            }
+            const { transaction: signedTransaction, signature } =
+              await solanaWallet!.signTransaction({
+                transaction: transactionParam,
+              });
+            LogStore.log(
+              'Solana payment transaction signed',
+              'PaymentStore',
+              'approvePayment',
+              { chainId, step: stepLabel, signature },
+            );
+            signatures.push(signedTransaction);
             break;
           }
 


### PR DESCRIPTION
## Summary

Follow-up to #500. Wires Solana into the WalletConnect Pay flow of the RN CLI sample wallet so a Pay link whose merchant supports Solana now surfaces a SOL option and signs it through `SolanaLib`.

- `usePairing.handlePaymentLink` now sends `solana:<chain>:<pubkey>` alongside EVM entries in `getPaymentOptions({ accounts })`, so the backend can return SOL-denominated options.
- `PaymentStore.approvePayment` resolves the wallet **per action** by CAIP-2 namespace (no more eager `eip155Wallets[...]` lookup), relaxes the array-only param invariant, and adds a `solana_signTransaction` case that forwards the **base64 signed transaction blob** (not the bs58 signature) to `confirmPayment` so the backend can broadcast.
- Accepts the backend's array-wrapped `[{ transaction }]` params as well as the bare-object WC shape.
- `solana_signAndSendTransaction` is intentionally out of scope — backend broadcasts server-side.
- Adds three Solana-focused unit tests (array + object params + wallet-not-initialized) and bumps Android `versionCode` to 66.

## Flow

```mermaid
sequenceDiagram
  participant U as User
  participant W as RN Wallet
  participant Pay as Pay Backend
  participant Sol as SolanaLib
  U->>W: paste Pay link
  W->>Pay: getPaymentOptions({ accounts: [eip155..., solana...] })
  Pay-->>W: options (incl. SOL option)
  U->>W: tap Pay on SOL option
  W->>Pay: getRequiredPaymentActions
  Pay-->>W: [{ method: solana_signTransaction, params: [{ transaction }] }]
  W->>Sol: signTransaction({ transaction })
  Sol-->>W: { transaction: signedB64, signature }
  W->>Pay: confirmPayment({ signatures: [signedB64] })
  Pay-->>W: succeeded (backend broadcast)
```

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn jest __tests__/PaymentStore.test.ts` — 14/14 pass (incl. new Solana cases)
- [x] Manual: paste a Pay link with a SOL option, confirm `accounts[]` contains the `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:<pubkey>` entry and the flow ends with `succeeded`
- [x] EVM regression: existing Polygon USDC Pay flow still works end-to-end
- [x] Maestro Pay suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)