### PR TITLE
chore: change payment loader text

### DIFF
--- a/wallets/rn_cli_wallet/__tests__/PaymentStore.test.ts
+++ b/wallets/rn_cli_wallet/__tests__/PaymentStore.test.ts
@@ -611,10 +611,10 @@ describe('PaymentStore', () => {
 
     expect(PaymentStore.state.step).toBe('confirming');
     expect(PaymentStore.state.loadingMessage).toBe(
-      'Setting up USDT for one-time setup...',
+      'Setting up USDT',
     );
     expect(PaymentStore.state.loadingNote).toBe(
-      'Future USDT payments will be instant',
+      'This usually takes a few seconds. Future USDT payments will skip this step.',
     );
 
     deferredActions.resolve([

--- a/wallets/rn_cli_wallet/android/app/build.gradle
+++ b/wallets/rn_cli_wallet/android/app/build.gradle
@@ -85,7 +85,7 @@ android {
         applicationId "com.walletconnect.web3wallet.rnsample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 66
+        versionCode 67
         versionName "1.0"
         resValue "string", "build_config_package", "com.walletconnect.web3wallet.rnsample"
     }

--- a/wallets/rn_cli_wallet/src/store/PaymentStore.ts
+++ b/wallets/rn_cli_wallet/src/store/PaymentStore.ts
@@ -499,8 +499,8 @@ const PaymentStore = {
 
     state.step = 'confirming';
     if (showInitialSetupLoader) {
-      state.loadingMessage = `Setting up ${tokenSymbol} for one-time setup...`;
-      state.loadingNote = `Future ${tokenSymbol} payments will be instant`;
+      state.loadingMessage = `Setting up ${tokenSymbol}`;
+      state.loadingNote = `This usually takes a few seconds. Future ${tokenSymbol} payments will skip this step.`;
     } else {
       state.loadingMessage = null;
       state.loadingNote = null;
@@ -532,8 +532,8 @@ const PaymentStore = {
         }
 
         if (showSetupLoader && approvalAction && action === approvalAction) {
-          state.loadingMessage = `Setting up ${tokenSymbol} for one-time setup...`;
-          state.loadingNote = `Future ${tokenSymbol} payments will be instant`;
+          state.loadingMessage = `Setting up ${tokenSymbol}`;
+          state.loadingNote = `This usually takes a few seconds. Future ${tokenSymbol} payments will skip this step.`;
         } else {
           state.loadingMessage = null;
           state.loadingNote = null;


### PR DESCRIPTION
**User experience improvements:**

* Updated the `loadingMessage` and `loadingNote` in `PaymentStore` to remove "for one-time setup..." and clarify that the setup usually takes a few seconds and will be skipped for future payments. [[1]](diffhunk://#diff-287afaead9e29d033f1ee360ac9a8decc6dc1aad8b57b657b8930757ba93adefL502-R503) [[2]](diffhunk://#diff-287afaead9e29d033f1ee360ac9a8decc6dc1aad8b57b657b8930757ba93adefL535-R536)
* Updated related test expectations in `PaymentStore.test.ts` to match the new messages.

**Build configuration:**

* Incremented the Android `versionCode` from 66 to 67 in `build.gradle`.