### PR TITLE
chore(rn_cli_wallet): tweak WC Pay Lottie loader and success layouts

### DIFF
--- a/wallets/rn_cli_wallet/android/app/build.gradle
+++ b/wallets/rn_cli_wallet/android/app/build.gradle
@@ -85,7 +85,7 @@ android {
         applicationId "com.walletconnect.web3wallet.rnsample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 67
+        versionCode 68
         versionName "1.0"
         resValue "string", "build_config_package", "com.walletconnect.web3wallet.rnsample"
     }

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/LoadingView.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/LoadingView.tsx
@@ -8,7 +8,11 @@ import { useTheme } from '@/hooks/useTheme';
 import { Spacing } from '@/utils/ThemeUtil';
 import { Text } from '@/components/Text';
 
-import { arePayModalAnimationsEnabled } from './utils';
+import {
+  arePayModalAnimationsEnabled,
+  LOTTIE_ICON_SIZE,
+  PAY_STATUS_LAYOUT,
+} from './utils';
 
 interface LoadingViewProps {
   message?: string;
@@ -30,7 +34,7 @@ const exitingKeyframe = new Keyframe({
 export function LoadingView({
   message,
   note,
-  size = 120,
+  size,
   variant = 'lottie',
 }: LoadingViewProps) {
   const Theme = useTheme();
@@ -57,31 +61,32 @@ export function LoadingView({
 
   const resolvedVariant = arePayModalAnimationsEnabled ? variant : 'spinner';
 
+  const lottieSize = size ?? LOTTIE_ICON_SIZE;
+
   return (
-    <View style={styles.loadingContainer}>
+    <>
       {resolvedVariant === 'spinner' ? (
-        <WalletConnectLoading size={size} />
+        <View style={styles.spinnerArea}>
+          <WalletConnectLoading size={size} />
+        </View>
       ) : (
-        <LottieView
-          source={require('@/assets/lottie/Loading.json')}
-          autoPlay
-          loop
-          colorFilters={lottieColorFilters}
-          style={{ width: size, height: size }}
-          testID="pay-loading-lottie"
-        />
+        <View style={styles.iconArea}>
+          <LottieView
+            source={require('@/assets/lottie/Loading.json')}
+            autoPlay
+            loop
+            colorFilters={lottieColorFilters}
+            style={{ width: lottieSize, height: lottieSize }}
+            testID="pay-loading-lottie"
+          />
+        </View>
       )}
-      <View
-        style={[
-          styles.messageContainer,
-          note && styles.messageContainerWithNote,
-        ]}
-      >
+      <View style={styles.textArea}>
         <Animated.View
           key={messageKey}
           entering={entering}
           exiting={arePayModalAnimationsEnabled ? exitingKeyframe : undefined}
-          style={styles.messageSlot}
+          style={styles.textSlot}
         >
           <Text
             variant="h6-400"
@@ -105,29 +110,27 @@ export function LoadingView({
           )}
         </Animated.View>
       </View>
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
-  loadingContainer: {
-    padding: Spacing[5],
+  iconArea: {
+    height: PAY_STATUS_LAYOUT.iconAreaHeight,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  messageContainer: {
-    marginTop: Spacing[4],
-    minHeight: 64,
+  spinnerArea: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing[4],
+  },
+  textArea: {
     width: '100%',
-    overflow: 'hidden',
+    paddingVertical: Spacing[4],
   },
-  messageContainerWithNote: {
-    minHeight: 110,
-  },
-  messageSlot: {
-    ...StyleSheet.absoluteFill,
+  textSlot: {
     alignItems: 'center',
-    justifyContent: 'center',
     paddingHorizontal: Spacing[2],
   },
   loadingText: {

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ResultView.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ResultView.tsx
@@ -10,7 +10,12 @@ import { haptics } from '@/utils/haptics';
 import { Spacing } from '@/utils/ThemeUtil';
 
 import type { ErrorType } from './utils';
-import { arePayModalAnimationsEnabled, getErrorTitle } from './utils';
+import {
+  arePayModalAnimationsEnabled,
+  getErrorTitle,
+  LOTTIE_ICON_SIZE,
+  PAY_STATUS_LAYOUT,
+} from './utils';
 
 const getResultButtonTestId = (
   isSuccess: boolean,
@@ -121,7 +126,6 @@ export function ResultView({
           variant="h6-400"
           color="text-primary"
           center
-          style={styles.title}
           numberOfLines={2}
           testID="pay-result-title"
         >
@@ -136,7 +140,6 @@ export function ResultView({
           variant="h6-400"
           color="text-primary"
           center
-          style={styles.title}
           testID="pay-result-title"
         >
           {message || defaultMessage}
@@ -149,7 +152,6 @@ export function ResultView({
         variant="h6-400"
         color="text-primary"
         center
-        style={styles.title}
         testID="pay-result-title"
       >
         {getErrorTitle(errorType)}
@@ -159,8 +161,10 @@ export function ResultView({
 
   return (
     <>
-      <View style={styles.contentContainer} testID="pay-result-container">
+      <View style={styles.iconArea} testID="pay-result-container">
         {renderIcon()}
+      </View>
+      <View style={styles.textArea}>
         {renderTitle()}
         {!isSuccess && (
           <Text
@@ -192,22 +196,27 @@ export function ResultView({
 }
 
 const styles = StyleSheet.create({
-  contentContainer: {
+  iconArea: {
+    height: PAY_STATUS_LAYOUT.iconAreaHeight,
     alignItems: 'center',
+    justifyContent: 'center',
   },
   successAnimation: {
-    width: 120,
-    height: 120,
+    width: LOTTIE_ICON_SIZE,
+    height: LOTTIE_ICON_SIZE,
   },
-  title: {
-    marginTop: Spacing[4],
+  textArea: {
+    width: '100%',
+    paddingHorizontal: Spacing[2],
+    paddingVertical: Spacing[4],
+    alignItems: 'center',
   },
   message: {
     marginTop: Spacing[1],
   },
   footerContainer: {
-    paddingTop: Spacing[7],
-    marginBottom: Spacing[2],
+    paddingTop: Spacing[2],
+    paddingBottom: Spacing[2],
     alignItems: 'center',
   },
 });

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ResultView.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ResultView.tsx
@@ -161,7 +161,10 @@ export function ResultView({
 
   return (
     <>
-      <View style={styles.iconArea} testID="pay-result-container">
+      <View
+        style={isSuccess ? styles.iconArea : styles.iconAreaCompact}
+        testID="pay-result-container"
+      >
         {renderIcon()}
       </View>
       <View style={styles.textArea}>
@@ -200,6 +203,11 @@ const styles = StyleSheet.create({
     height: PAY_STATUS_LAYOUT.iconAreaHeight,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  iconAreaCompact: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing[4],
   },
   successAnimation: {
     width: LOTTIE_ICON_SIZE,

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ViewWrapper.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ViewWrapper.tsx
@@ -1,6 +1,10 @@
 import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated';
 import Config from 'react-native-config';
 
 import { useTheme } from '@/hooks/useTheme';
@@ -21,6 +25,7 @@ interface ViewWrapperProps {
 }
 
 const ANIMATION_DURATION = 250;
+const LAYOUT_TRANSITION_DURATION = 280;
 const arePayModalAnimationsEnabled = Config.ENV_TEST_MODE !== 'true';
 
 export function ViewWrapper({
@@ -106,9 +111,16 @@ export function ViewWrapper({
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: Theme['bg-primary'] }]}>
+    <Animated.View
+      style={[styles.container, { backgroundColor: Theme['bg-primary'] }]}
+      layout={
+        arePayModalAnimationsEnabled
+          ? LinearTransition.duration(LAYOUT_TRANSITION_DURATION)
+          : undefined
+      }
+    >
       {content}
-    </View>
+    </Animated.View>
   );
 }
 

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ViewWrapper.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ViewWrapper.tsx
@@ -5,7 +5,6 @@ import Animated, {
   FadeOut,
   LinearTransition,
 } from 'react-native-reanimated';
-import Config from 'react-native-config';
 
 import { useTheme } from '@/hooks/useTheme';
 import SvgArrowLeft from '@/assets/ArrowLeft';
@@ -13,6 +12,8 @@ import { Spacing, BorderRadius } from '@/utils/ThemeUtil';
 import { ModalCloseButton } from '@/components/ModalCloseButton';
 import { Button } from '@/components/Button';
 import type { Step } from '@/utils/TypesUtil';
+
+import { arePayModalAnimationsEnabled } from './utils';
 
 interface ViewWrapperProps {
   children: React.ReactNode;
@@ -26,7 +27,6 @@ interface ViewWrapperProps {
 
 const ANIMATION_DURATION = 250;
 const LAYOUT_TRANSITION_DURATION = 280;
-const arePayModalAnimationsEnabled = Config.ENV_TEST_MODE !== 'true';
 
 export function ViewWrapper({
   children,

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/utils.ts
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/utils.ts
@@ -2,6 +2,18 @@ import Config from 'react-native-config';
 
 export const arePayModalAnimationsEnabled = Config.ENV_TEST_MODE !== 'true';
 
+// The Loading.json / Success.json artwork has inner padding inside its
+// 1080×1080 canvas, so the visible glyph is smaller than the container.
+export const LOTTIE_ICON_SIZE = 200;
+
+// Shared icon area height for the LoadingView + ResultView screens. The fixed
+// height keeps the Lottie centered at the same Y across the loading -> success
+// transition, so the W and check don't jump. Text and any button below size
+// naturally — the ViewWrapper's LinearTransition animates the modal growth.
+export const PAY_STATUS_LAYOUT = {
+  iconAreaHeight: 200,
+} as const;
+
 // Format date input as user types (YYYY-MM-DD)
 export function formatDateInput(value: string): string {
   // Remove any non-numeric characters except dashes


### PR DESCRIPTION
## Summary

Designer follow-up to PR #504 (Lottie animations for WC Pay loader / success). Fixes the W and check appearing too small, the copy shifting between the confirming and success states, and a couple of layout voids spotted on device.

## Changes

- **Bigger glyph** — `LOTTIE_ICON_SIZE` bumped to 200, with a shared `iconAreaHeight: 200` constant in `PaymentOptionsModal/utils.ts` so the W (confirming) and check (success) land at exactly the same Y. The squares spinner used by the *initial* loader stays at its natural size in its own compact area — no 200px void around it.
- **No empty space below the copy** — the previously fixed-height text area is now naturally sized in both `LoadingView` and `ResultView`, so the confirming view ends right under "Processing your payment…" instead of leaving a button-shaped void.
- **Smooth modal resize** — `ViewWrapper` is now an `Animated.View` with `LinearTransition.duration(280)`, so the loading → success size change (button appearing, modal growing) animates instead of snapping.
- Android `versionCode` bumped 67 → 68.

## Flow

```mermaid
flowchart LR
  A[Initial<br/>squares spinner<br/>~208px] --> B[Confirming<br/>W Lottie 200px<br/>~256px]
  B -- LinearTransition 280ms --> C[Success<br/>check Lottie 200px<br/>+ Got it! button<br/>~352px]
```

## Test plan

- [x] iOS & Android: trigger a WC Pay flow, confirm the W and check render at ~200px, the copy doesn't jump on the confirming → success transition, and the modal grows smoothly.
- [x] Initial "Preparing your payment…" screen looks compact (no white space around the squares animation or below the text).
- [x] Maestro pay flows still pass (test IDs unchanged: \`pay-loading-lottie\`, \`pay-loading-message\`, \`pay-result-success-icon\`, \`pay-result-title\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)