### PR TITLE
ci(walletkit): bump pay-tests/setup ref to 70301a8 (deeplink 60s timeout)

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -73,7 +73,7 @@ inputs:
   maestro-actions-ref:
     description: 'Pinned ref of WalletConnect/actions for maestro/pay-tests and maestro/setup.'
     required: false
-    default: 'afc741fbe638ca13cfc10de2ed59b064c2b59436'
+    default: '70301a88d7465309d5553376655a46cbba3cbcae'
   apple-key-id:
     description: 'Apple App Store Connect API key id (iOS only).'
     required: false
@@ -392,10 +392,10 @@ runs:
 
     # --- Common: Maestro setup + run ---
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@afc741fbe638ca13cfc10de2ed59b064c2b59436
+      uses: WalletConnect/actions/maestro/pay-tests@70301a88d7465309d5553376655a46cbba3cbcae
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@afc741fbe638ca13cfc10de2ed59b064c2b59436
+      uses: WalletConnect/actions/maestro/setup@70301a88d7465309d5553376655a46cbba3cbcae
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'


### PR DESCRIPTION
## Summary

Bumps the hardcoded \`WalletConnect/actions/maestro/pay-tests\` and \`maestro/setup\` refs in \`walletkit-build-and-maestro/action.yml\` from \`afc741fb\` → \`70301a8\`. Updates the input default in lockstep.

The new ref picks up [WalletConnect/actions#88](https://github.com/WalletConnect/actions/pull/88) — \`pay_single_option_nokyc_deeplink.yaml\`'s timeout for \`pay-merchant-info\` bumped 30s → 60s.

## Why

The deep-link flow is the only one in the suite that opens the wallet from cold via Android intent (\`stopApp\` + \`openLink\` in \`flows/pay_open_via_deeplink.yaml\`). Every other flow inherits a warm process from \`pay_open_and_paste_url.yaml\`'s \`launchApp\`.

On a contended GHA Ubuntu runner with \`reactivecircus/android-emulator-runner\` (4GB RAM, swiftshader GPU, x86_64 API 34), the cold-start path consistently takes 20-40s: ActivityManager fork → process attach to system_server → APK load → Hermes init → RN bridge → JS bundle (~10MB Hermes bytecode) → deep-link router → API call to pay-core → merchant info render.

Pay-core CD run [26570588681](https://github.com/WalletConnect/pay-core/actions/runs/26570588681/job/78278044790) on \`afc741fb\` caught the worst case: at 11:45:35 UTC \`ActivityManager: Process ... failed to attach\` — ActivityManager had to re-fork the wallet process. By the time Hermes was up and the API call returned, the 30s budget was gone. Screenshot at the timeout showed the wallet still on the splash screen.

## What this PR does NOT change

- Other flows keep their 30s/45s timeouts — they don't share the cold-start path.
- Only behavioural impact: the deep-link flow can take up to 30s longer worst-case, **only when it would have failed at 30s anyway**.

## Why both refs bumped together

\`maestro/pay-tests\` and \`maestro/setup\` are pinned to the same SHA on each line — the deep-link timeout change touches only \`pay-tests/\`, but keeping both refs in sync keeps the upstream change visible as one diff. \`setup\` is unchanged between \`afc741fb\` and \`70301a8\`.

## Test plan

- [ ] \`ci_e2e_walletkit.yaml\` hourly schedule stays green on the deep-link flow over the next ~6 runs
- [ ] reown-kotlin \`ci_e2e_pay_tests.yml\` (which uses the actions ref directly, not this composite) is unaffected (it's already on \`afc741fb\` and can pick up the new ref independently)
- [ ] pay-core PR [#630](https://github.com/WalletConnect/pay-core/pull/630) soak shows ≥95% pass on the deep-link flow after WALLETKIT_RN_REF is bumped to a SHA that includes this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)