### PR TITLE
ci(walletkit): overwrite Maestro artifacts so cross-repo retry doesn't 409

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -468,6 +468,11 @@ runs:
           maestro-output.log
         if-no-files-found: warn
         retention-days: 14
+        # Allow callers to invoke this composite twice in the same run
+        # (e.g. a retry wrapper) without the second upload 409'ing
+        # against the first. Last-wins; combine with an out-of-action
+        # download+rename step if both attempts' artifacts are needed.
+        overwrite: true
 
     - name: Run Maestro tests (Android)
       if: inputs.platform == 'android'
@@ -522,6 +527,11 @@ runs:
           maestro-output.log
         if-no-files-found: warn
         retention-days: 14
+        # Allow callers to invoke this composite twice in the same run
+        # (e.g. a retry wrapper) without the second upload 409'ing
+        # against the first. Last-wins; combine with an out-of-action
+        # download+rename step if both attempts' artifacts are needed.
+        overwrite: true
 
     - name: Log Maestro outcome
       if: always()


### PR DESCRIPTION
## Summary

Adds \`overwrite: true\` to both \`actions/upload-artifact@v4\` steps in \`walletkit-build-and-maestro/action.yml\` (iOS + Android).

## Why

Cross-repo callers (e.g. pay-core) sometimes wrap this composite in a one-shot retry: invoke once, on failure invoke again. Without \`overwrite: true\`, the second invocation's upload-artifact step 409s against the first artifact (same hardcoded \`name:\`):

\`\`\`
##[error]Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
\`\`\`

Even when the second Maestro run actually succeeded, the upload 409 fails the composite step and propagates as failure. The caller can't tell retry recovery from real Maestro failure.

Observed on pay-core CD run [26570588681](https://github.com/WalletConnect/pay-core/actions/runs/26570588681/job/78278044790).

## Alternative considered

The caller could delete the prior artifact via the GitHub API before re-invoking. That needs \`actions: write\` propagated all the way down the caller's workflow chain (pay-core: \`event_release.yml\` → \`sub-cd.yml\` → \`sub-validate.yml\`, plus \`dispatch_deploy.yml\` and \`dispatch_validate.yml\`). When pay-core tried that, declaring \`actions: write\` on \`sub-validate.yml\` without granting it on every caller produced an immediate \`startup_failure\` ([run 26576480201](https://github.com/WalletConnect/pay-core/actions/runs/26576480201)). A one-line behaviour change in the composite where the artifact is actually produced is substantially less invasive.

## Tradeoff

Only one attempt's artifact survives in the run — last-write-wins. If a caller needs both attempts' diagnostics, they can download + re-upload under a distinct name between invocations (which doesn't need any extra permission). For single-invocation callers (every existing use site), behaviour is unchanged.

## Test plan

- [ ] \`ci_e2e_walletkit.yaml\` hourly schedule keeps producing the \`maestro-{ios,android}-artifacts\` artifact normally (single invocation — unaffected)
- [ ] pay-core PR [#630](https://github.com/WalletConnect/pay-core/pull/630) re-adds the retry wrapper once this lands and \`WALLETKIT_RN_REF\` is bumped, then soaks ≥10 runs at ≥95% pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)