### PR TITLE
ci(walletkit): bump pay-tests ref to 6628a30 (paste-URL button-scan 60s)

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -73,7 +73,7 @@ inputs:
   maestro-actions-ref:
     description: 'Pinned ref of WalletConnect/actions for maestro/pay-tests and maestro/setup.'
     required: false
-    default: '70301a88d7465309d5553376655a46cbba3cbcae'
+    default: '6628a30e8e92ab36c1051e6f62b68add6a737f3f'
   apple-key-id:
     description: 'Apple App Store Connect API key id (iOS only).'
     required: false
@@ -392,10 +392,10 @@ runs:
 
     # --- Common: Maestro setup + run ---
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@70301a88d7465309d5553376655a46cbba3cbcae
+      uses: WalletConnect/actions/maestro/pay-tests@6628a30e8e92ab36c1051e6f62b68add6a737f3f
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@70301a88d7465309d5553376655a46cbba3cbcae
+      uses: WalletConnect/actions/maestro/setup@6628a30e8e92ab36c1051e6f62b68add6a737f3f
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'


### PR DESCRIPTION
## Summary

Bumps the hardcoded \`WalletConnect/actions/maestro/{pay-tests,setup}\` refs in \`walletkit-build-and-maestro/action.yml\` from \`70301a8\` → \`6628a30\`. Updates the input default in lockstep.

The new ref picks up [WalletConnect/actions#89](https://github.com/WalletConnect/actions/pull/89) — \`pay_open_and_paste_url.yaml\`'s timeout for \`button-scan\` bumped 15s → 60s.

## Why

Every flow that uses \`pay_open_and_paste_url.yaml\` runs \`clearState\` first (in the parent flow). \`clearState\` force-stops the wallet — so the subsequent \`launchApp\` triggers a full cold start, not a foreground:

1. ActivityManager fork from zygote
2. Process attach to \`system_server\`
3. APK load, Hermes init
4. RN bridge boot, JS bundle (~10MB Hermes bytecode)
5. Home screen render → \`button-scan\` visible

On a contended GHA emulator the first fork can hit \`ActivityManager: Process ... failed to attach\`, ActivityManager re-forks, and total time-to-render is ~30-40s. The 15s budget was consistently too tight.

## Evidence

pay-core CD run [26580944640](https://github.com/WalletConnect/pay-core/actions/runs/26580944640/job/78315481185) on \`7733a23\` (the previous RN pin):

- Both retry attempts in the in-job retry wrapper failed deterministically at \`Multiple Options No KYC\`, always after exactly 20s
- Failure assertion: \`Assertion is false: id: button-scan is visible\`
- Screenshot: black screen (process forked, not yet attached/rendered)
- Logcat at the failure moment:
  \`\`\`
  ActivityManager: Process ProcessRecord{... :com.walletconnect.web3wallet.rnsample.internal} failed to attach
  \`\`\`
  RN errors didn't appear until 38s after \`launchApp\` — well past the 15s Maestro timeout.

## Tradeoff

60s extra worst-case wait time on this shared subflow, only when \`launchApp\` hits a cold-start race. Happy path is unaffected — \`extendedWaitUntil\` exits as soon as the element renders, typically <5s on a warm process. Every flow that uses this subflow benefits.

## Test plan

- [ ] \`ci_e2e_walletkit.yaml\` hourly schedule keeps producing green runs
- [ ] pay-core PR [#630](https://github.com/WalletConnect/pay-core/pull/630) soak ≥10 runs at ≥95% pass after \`WALLETKIT_RN_REF\` is bumped to a SHA that includes this

🤖 Generated with [Claude Code](https://claude.com/claude-code)