### PR TITLE
fix(rn_cli_wallet): disable GWP-ASan to avoid Hermes coroutine SIGSEGV

### DIFF
--- a/wallets/rn_cli_wallet/android/app/src/main/AndroidManifest.xml
+++ b/wallets/rn_cli_wallet/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,18 @@
     android:allowBackup="false"
     android:theme="@style/AppTheme"
     android:usesCleartextTraffic="true"
-    android:supportsRtl="true">
+    android:supportsRtl="true"
+    android:gwpAsanMode="never"><!--
+      Disabled to avoid a SIGSEGV in libhermesvm.so that surfaced when
+      RN was upgraded to 0.85.3 (#420). Hermes's new Boost.Context-based
+      coroutine scheduler (`hoost_make_fcontext`) synthesizes stacks
+      with no valid frame-pointer chain at the bottom; when GWP-ASan
+      samples an allocation on such a stack, its frame-pointer walker
+      (`android_unsafe_frame_pointer_chase`) reads past the stack end
+      into a guard page and the process crashes with SEGV_ACCERR ~4s
+      after launch. Repros at ~15-20% rate on Android-14 x86_64
+      emulator; see pay-core PR #630 for the full forensics.
+    -->
     <activity
       android:name=".MainActivity"
       android:label="@string/app_name"


### PR DESCRIPTION
## Summary

Adds `android:gwpAsanMode="never"` to the wallet's `<application>` element in `wallets/rn_cli_wallet/android/app/src/main/AndroidManifest.xml`.

This eliminates a SIGSEGV that was introduced by #420 (RN 0.82.0 → 0.85.3) and surfaces deterministically as a crash on cold app start at a ~15-20% rate on Android-14 x86_64 emulators (and likely on real Android-14 devices too).

## Root cause

RN 0.85.3 ships a new Hermes with a Boost.Context-based coroutine scheduler. The stack-creating symbol `hoost_make_fcontext` (renamed `boost::context::detail::make_fcontext` to avoid ABI conflicts) synthesizes a new stack on each coroutine creation, but **doesn't install a frame-pointer sentinel at the bottom**.

When GWP-ASan (libc's lightweight heap-safety sampler, default-on for apps targeting recent Android) samples an allocation that happens to be on a Hermes coroutine stack, it tries to record a call-site backtrace. The recorder calls `android_unsafe_frame_pointer_chase`, which walks `rbp` upward… past the top of the coroutine stack… into the guard page that delimits it. Read of `[rbp+8]` traps with `SEGV_ACCERR` and the process dies.

Both observed crashes on pay-core CI had identical signatures across different process IDs, with `fault_addr == rcx + 8` always page-aligned. Classic guard-page-on-frame-walk.

Full crash backtrace:

```
F libc    : Fatal signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr 0x...000 in tid N (sample.internal)
F DEBUG   : Process uptime: 4s
F DEBUG   : backtrace:
  #00 pc 00000000000cfd45  libc.so (android_unsafe_frame_pointer_chase+117)
  #01 pc 0000000000051a77  libc.so (gwp_asan::AllocationMetadata::CallSiteInfo::RecordBacktrace+87)
  #02 pc 000000000005230c  libc.so (gwp_asan::GuardedPoolAllocator::deallocate+380)
  #03-#11 libhermesvm.so (Hermes internals)
  #12 pc 00000000000ae48e  libhermesvm.so (hoost_make_fcontext+46)
```

## Why this PR

Three escape hatches:

1. **`android:gwpAsanMode=\"never\"`** ← this PR. One-line, official Android API: https://developer.android.com/ndk/guides/gwp-asan#disabling-gwp-asan
2. Patch Hermes to install a frame-pointer sentinel at the bottom of coroutine stacks — the real fix. Needs a PR upstream at facebook/hermes; long lead time.
3. Patch bionic's `android_unsafe_frame_pointer_chase` to validate page permissions before dereferencing — AOSP-side, won't ship to existing Android versions.

#1 is the right immediate fix. #2 is worth filing as a tracking issue with the Hermes team; I'm happy to draft it. #3 isn't actionable.

## Trade-off

Disabling GWP-ASan means we lose its lightweight heap-bug detection in this app's process. The trade is small in practice — GWP-ASan only samples ~1/N allocations (boot-time tunable), and any sampled dealloc on a Hermes coroutine stack now crashes the app instead of catching anything, so the net memory-safety value with Hermes-Boost.Context-coroutines + GWP-ASan was already heavily negative.

Production users on Android 14 are almost certainly hitting this crash today.

## Evidence

Full forensics in pay-core PR [#630](https://github.com/WalletConnect/pay-core/pull/630). Two crashes observed on the same wallet pin (`5592fc1`) in run [26629151448](https://github.com/WalletConnect/pay-core/actions/runs/26629151448):

| | Attempt 1 (pid 5421) | Attempt 2 (pid 3483) |
|---|---|---|
| `fault_addr` | `0x709212514000` | `0x783d1cd7e000` |
| `rcx` | `0x709212513ff8` | `0x783d1cd7dff8` |
| `fault == rcx+8` | ✓ | ✓ |
| Page-aligned fault | ✓ | ✓ |
| `libhermesvm.so` BuildId | `499b43a64a8d7cd6702459b78ebbbc9e1626e0c7` | same |
| Bottom frame | `hoost_make_fcontext+46` | same |

## Test plan

- [ ] `ci_e2e_walletkit.yaml` hourly schedule stays green (the SIGSEGV repros there too — historic green rate was masking sampling luck)
- [ ] pay-core PR [#630](https://github.com/WalletConnect/pay-core/pull/630) PR-time `wx-pay-e2e-maestro` job goes green on attempt 1 consistently after this lands and the pin is bumped (currently relying on a one-shot retry to mask the crash)
- [ ] Manual cold-start × 20 on `app-internal` on an Android-14 x86_64 emulator after this lands — should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)