### PR TITLE
fix(rn_cli_wallet): fix one-click-auth chain check + improve unsupported-networks copy

### DIFF
--- a/wallets/rn_cli_wallet/android/app/build.gradle
+++ b/wallets/rn_cli_wallet/android/app/build.gradle
@@ -85,7 +85,7 @@ android {
         applicationId "com.walletconnect.web3wallet.rnsample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 68
+        versionCode 69
         versionName "1.0"
         resValue "string", "build_config_package", "com.walletconnect.web3wallet.rnsample"
     }

--- a/wallets/rn_cli_wallet/src/hooks/useWalletKitEventsManager.ts
+++ b/wallets/rn_cli_wallet/src/hooks/useWalletKitEventsManager.ts
@@ -41,7 +41,11 @@ export default function useWalletKitEventsManager(initialized: boolean) {
       );
 
       if (chains.length === 0) {
-        ModalStore.open('LoadingModal', { errorMessage: 'Unsupported chains' });
+        ModalStore.open('LoadingModal', {
+          errorTitle: "These networks aren’t supported",
+          errorMessage:
+            'This wallet doesn’t support any of the networks this app requested. Try connecting to a different app.',
+        });
       } else {
         ModalStore.open('SessionProposalModal', { proposal });
       }
@@ -201,11 +205,15 @@ export default function useWalletKitEventsManager(initialized: boolean) {
         },
       );
       const chains = authRequest.params.authPayload.chains.filter(
-        chain => !!EIP155_CHAINS[chain.split(':')[1]],
+        chain => !!EIP155_CHAINS[chain],
       );
 
       if (chains.length === 0) {
-        ModalStore.open('LoadingModal', { errorMessage: 'Unsupported chains' });
+        ModalStore.open('LoadingModal', {
+          errorTitle: "These networks aren’t supported",
+          errorMessage:
+            'This wallet doesn’t support any of the networks this app requested. Try connecting to a different app.',
+        });
       } else {
         ModalStore.open('SessionAuthenticateModal', { authRequest });
       }

--- a/wallets/rn_cli_wallet/src/modals/LoadingModal.tsx
+++ b/wallets/rn_cli_wallet/src/modals/LoadingModal.tsx
@@ -16,10 +16,10 @@ export function LoadingModal() {
   const { data } = useSnapshot(ModalStore.state);
 
   useEffect(() => {
-    if (data?.errorMessage) {
+    if (data?.errorMessage || data?.errorTitle) {
       haptics.error();
     }
-  }, [data?.errorMessage]);
+  }, [data?.errorMessage, data?.errorTitle]);
 
   const onClose = () => {
     ModalStore.close();
@@ -37,7 +37,7 @@ export function LoadingModal() {
   return (
     <View style={[styles.container, { backgroundColor: Theme['bg-primary'] }]}>
       <ModalCloseButton onPress={onClose} style={styles.closeButton} />
-      {data?.errorMessage ? (
+      {data?.errorMessage || data?.errorTitle ? (
         <Icon name="warningCircle" color="text-error" width={48} height={48} />
       ) : (
         <WalletConnectLoading size={120} />

--- a/wallets/rn_cli_wallet/src/modals/LoadingModal.tsx
+++ b/wallets/rn_cli_wallet/src/modals/LoadingModal.tsx
@@ -25,6 +25,15 @@ export function LoadingModal() {
     ModalStore.close();
   };
 
+  // When an errorTitle is set, it acts as the heading and errorMessage as the
+  // supporting body. Otherwise fall back to the single-line legacy behavior.
+  const title =
+    data?.errorTitle ||
+    data?.loadingMessage ||
+    data?.errorMessage ||
+    'Loading...';
+  const body = data?.errorTitle ? data?.errorMessage : undefined;
+
   return (
     <View style={[styles.container, { backgroundColor: Theme['bg-primary'] }]}>
       <ModalCloseButton onPress={onClose} style={styles.closeButton} />
@@ -33,9 +42,16 @@ export function LoadingModal() {
       ) : (
         <WalletConnectLoading size={120} />
       )}
-      <Text center variant="h6-400" color="text-primary">
-        {data?.loadingMessage || data?.errorMessage || 'Loading...'}
-      </Text>
+      <View style={styles.textContainer}>
+        <Text center variant="h6-400" color="text-primary">
+          {title}
+        </Text>
+        {body ? (
+          <Text center variant="md-400" color="text-secondary">
+            {body}
+          </Text>
+        ) : null}
+      </View>
     </View>
   );
 }
@@ -49,6 +65,10 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: BorderRadius[8],
     borderTopRightRadius: BorderRadius[8],
     rowGap: Spacing[4],
+  },
+  textContainer: {
+    alignItems: 'center',
+    rowGap: Spacing[2],
   },
   closeButton: {
     marginRight: Spacing[1],

--- a/wallets/rn_cli_wallet/src/modals/SessionAuthenticateModal.tsx
+++ b/wallets/rn_cli_wallet/src/modals/SessionAuthenticateModal.tsx
@@ -41,7 +41,7 @@ export default function SessionAuthenticateModal() {
   // the chains that are supported by the wallet from the proposal
   const supportedChains = useMemo(() => {
     const chains = authRequest.params.authPayload.chains.filter(
-      chain => !!EIP155_CHAINS[chain.split(':')[1]],
+      chain => !!EIP155_CHAINS[chain],
     );
     return chains;
   }, [authRequest]);

--- a/wallets/rn_cli_wallet/src/store/ModalStore.ts
+++ b/wallets/rn_cli_wallet/src/store/ModalStore.ts
@@ -11,6 +11,7 @@ interface ModalData {
   requestSession?: SessionTypes.Struct;
   authRequest?: SignClientTypes.EventArguments['session_authenticate'];
   loadingMessage?: string;
+  errorTitle?: string;
   errorMessage?: string;
   session?: SessionTypes.Struct;
 }


### PR DESCRIPTION
## Problem

Scanning a `wc_sessionAuthenticate` (one-click auth) URI in `rn_cli_wallet` **always** landed on the "Unsupported chains" error modal, even for supported networks like Ethereum mainnet.

The chain filter in `onSessionAuthenticate` and `SessionAuthenticateModal` looked up `EIP155_CHAINS[chain.split(':')[1]]` — i.e. it reduced `"eip155:1"` to `"1"`. But `EIP155_CHAINS` is keyed by the **full CAIP-2 id** (`'eip155:1'`), so every chain resolved to `undefined`, `chains.length` was always `0`, and the error modal opened unconditionally.

Example failing URI:
```
wc:7c982b85...@2?expiryTimestamp=1780059748&methods=wc_sessionAuthenticate&relay-protocol=irn&symKey=...
```

## Fix

- Use the full CAIP-2 id (`EIP155_CHAINS[chain]`) in both the event handler (`useWalletKitEventsManager`) and `SessionAuthenticateModal`. Supported auth chains now pass the filter; the modal opens as expected.
- Rework the genuine "no supported networks" error against the [WalletConnect UX Writing Guidelines](https://www.notion.so/walletconnect/UX-Writing-Guidelines-34f3a661771e80779f26e292ee109f93):
  - **Before:** `Unsupported chains`
  - **After — Title:** These networks aren't supported
  - **After — Body:** This wallet doesn't support any of the networks this app requested. Try connecting to a different app.
  - Follows §4.8 (what happened / why / what to do next), §6 (*network*, not *chain*), §3 (direct address), §7 (sentence case).
- Add an optional `errorTitle` to `LoadingModal` for the title + body layout. Backward compatible — the existing single-line `errorMessage` callers (`usePairing`, `App.tsx`) are unaffected.

## Files

- `src/hooks/useWalletKitEventsManager.ts` — fix lookup (proposal + auth paths) + new copy
- `src/modals/SessionAuthenticateModal.tsx` — fix lookup
- `src/modals/LoadingModal.tsx` — optional title + body rendering
- `src/store/ModalStore.ts` — add `errorTitle?`

## Testing

- `yarn tsc --noEmit` → pass
- `eslint` on changed files → pass
- Not yet verified on a device/simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)