### PR TITLE
fix(ci): drop pods cache restore-keys to avoid stale Pods on dep bumps

### DIFF
--- a/.github/workflows/release-ios-base.yaml
+++ b/.github/workflows/release-ios-base.yaml
@@ -149,9 +149,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ inputs.root-path }}/ios/Pods
+          # No restore-keys fallback on purpose: a prefix match would restore a
+          # stale Pods/ whenever Podfile.lock changes (e.g. a dependency bump),
+          # and its Pods/Local Podspecs no longer match the resolved podspecs
+          # (notably hermes-engine), breaking `pod install`. Only an exact
+          # Podfile.lock match restores; otherwise we start clean and reinstall.
           key: ${{ runner.os }}-pods-${{ github.ref_name }}-${{ hashFiles(env.podfile_path) }}
-          restore-keys: |
-            ${{ runner.os }}-pods-${{ github.ref_name }}-
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Problem

The iOS release lane (`release_testflight`) has been failing during `pod install`:

```
[!] CocoaPods could not find compatible versions for pod "hermes-engine":
It seems like you've changed the version of the dependency `hermes-engine`
and it differs from the version stored in `Pods/Local Podspecs`.
```

Failing runs: [26578560291](https://github.com/reown-com/react-native-examples/actions/runs/26578560291), [26640641412](https://github.com/reown-com/react-native-examples/actions/runs/26640641412). (Android builds were unaffected.)

## Root cause

`release-ios-base.yaml` cached `ios/Pods` with a `restore-keys` prefix fallback:

```yaml
key:          ${{ runner.os }}-pods-${{ github.ref_name }}-${{ hashFiles(env.podfile_path) }}
restore-keys: |
  ${{ runner.os }}-pods-${{ github.ref_name }}-
```

After the RN 0.85.3 bump, `Podfile.lock` changed (new `hermes-engine` version), so the exact key missed — but the `restore-keys` prefix still restored a **stale `Pods/`** from a pre-0.85.3 build. Its `Pods/Local Podspecs/hermes-engine.podspec.json` no longer matched the resolved podspec, breaking `pod install` resolution. Because the lane runs `cocoapods(clean_install: false)`, that stale dir was reused rather than reinstalled.

The prefix also has no project segment (`<os>-pods-<branch>-` is shared by every iOS project on a branch), so an inexact restore could even pull a different project's `Pods/`.

## Fix

Remove the `restore-keys` fallback. A cache is now restored **only on an exact `Podfile.lock` hash match**:

- **Deps unchanged** → exact hit → `Pods/` reused → fast install (no change from today).
- **Deps changed** → no restore → clean `pod install`, then a fresh cache saved under the new key.

Self-healing for any future dependency bump, and closes the cross-project restore leak. No changes to the Fastfile flags.

This base workflow is shared, so `release-walletkit`, `release-appkit`, `release-pos`, and `release-pos-poc` all inherit the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)