### PR TITLE
chore: add placeholder Create iOS App + Release Merchant POS workflows

### DIFF
--- a/.github/workflows/create-ios-app.yaml
+++ b/.github/workflows/create-ios-app.yaml
@@ -1,0 +1,15 @@
+name: Create iOS App
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    name: Placeholder Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do nothing
+        run: echo "Placeholder to enable manual dispatch from feature branches. The real workflow lives on the feature branch — run it via 'Use workflow from'."

--- a/.github/workflows/release-merchant-pos.yaml
+++ b/.github/workflows/release-merchant-pos.yaml
@@ -1,0 +1,15 @@
+name: Release Merchant POS
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    name: Placeholder Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do nothing
+        run: echo "Placeholder to enable manual dispatch from feature branches. The real workflow lives on the feature branch — run it via 'Use workflow from'."


### PR DESCRIPTION
## What

Adds two minimal \`workflow_dispatch\` **placeholder** workflows on \`main\`:

- \`.github/workflows/create-ios-app.yaml\`
- \`.github/workflows/release-merchant-pos.yaml\`

Each is just a no-op job (echo) — same pattern as #451.

## Why

\`workflow_dispatch\` workflows only show the **Run workflow** button once they exist on the
default branch. Merging these placeholders unlocks manual dispatch, after which the **real**
implementations (on \`feat/merchant-pos-app\`) can be run via **"Use workflow from: \<branch\>"** —
GitHub executes the workflow file from the selected branch, so we can test the full Create iOS
App / Release Merchant POS pipelines without first merging them to \`main\`.

The real workflows + fastlane lanes + runbook land separately on \`feat/merchant-pos-app\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)