### PR TITLE
feat(rn-cli-wallet): filter spam tokens from balance list

### DIFF
--- a/wallets/rn_cli_wallet/__tests__/SpamFilter.test.ts
+++ b/wallets/rn_cli_wallet/__tests__/SpamFilter.test.ts
@@ -1,0 +1,38 @@
+import { isSpamToken } from '../src/utils/SpamFilter';
+
+describe('isSpamToken', () => {
+  it('flags symbols embedding URLs or protocols', () => {
+    expect(isSpamToken('ecAVAX - https://invest')).toBe(true);
+    expect(isSpamToken('claim at http://scam.io')).toBe(true);
+    expect(isSpamToken('www.2base.cfd')).toBe(true);
+    expect(isSpamToken('token://airdrop')).toBe(true);
+  });
+
+  it('flags domain-like patterns', () => {
+    expect(isSpamToken('2base.cfd')).toBe(true);
+    expect(isSpamToken('gftpepe.com')).toBe(true);
+  });
+
+  it('flags bracketed advertising', () => {
+    expect(isSpamToken('USD0 [www.usual.finance]')).toBe(true);
+    expect(isSpamToken('REWARD ]')).toBe(true);
+  });
+
+  it('flags blocklisted symbols regardless of case/whitespace', () => {
+    expect(isSpamToken('BASED')).toBe(true);
+    expect(isSpamToken(' gt ')).toBe(true);
+    expect(isSpamToken('mantra pos')).toBe(true);
+  });
+
+  it('keeps legitimate token symbols', () => {
+    ['ETH', 'USDC', 'SOL', 'EURC', 'WBTC', 'TRX', 'SUI', 'TON'].forEach(
+      symbol => {
+        expect(isSpamToken(symbol)).toBe(false);
+      },
+    );
+  });
+
+  it('handles empty input', () => {
+    expect(isSpamToken('')).toBe(false);
+  });
+});

--- a/wallets/rn_cli_wallet/src/store/WalletStore.ts
+++ b/wallets/rn_cli_wallet/src/store/WalletStore.ts
@@ -4,6 +4,7 @@ import { TokenBalance } from '@/utils/BalanceTypes';
 import { fetchBalancesForChains } from '@/services/BalanceService';
 import { fetchERC20Balances } from '@/services/ERC20BalanceService';
 import { EIP155_CHAINS } from '@/constants/Eip155';
+import { isSpamToken } from '@/utils/SpamFilter';
 import { SOLANA_MAINNET_CAIP2 } from '@/constants/Solana';
 import LogStore, { serializeError } from '@/store/LogStore';
 
@@ -92,6 +93,8 @@ function processBalances(
 
   // Filter: keep tokens with value > 0, mainnet native tokens, or tokens with a non-zero quantity (on-chain ERC-20s without USD price)
   const filtered = apiBalances.filter(b => {
+    // Drop spam/airdrop token contracts (native rows have no address)
+    if (b.address && isSpamToken(b.symbol)) return false;
     if (b.value > 0) return true;
     if (mainnetChainIds.includes(b.chainId) && !b.address) return true;
     if (parseFloat(b.quantity.numeric) > 0) return true;

--- a/wallets/rn_cli_wallet/src/utils/SpamFilter.ts
+++ b/wallets/rn_cli_wallet/src/utils/SpamFilter.ts
@@ -1,0 +1,55 @@
+// Filters scam/airdrop tokens that disguise advertising in their symbol field.
+// Ported from reown-swift PR #312 (isSpam). Inspects only the token symbol:
+//   1. URL substrings (http://, https://, www., ://)
+//   2. Domain-like patterns (e.g. "2base.cfd")
+//   3. Brackets used for promos (e.g. "USD0 [www.usual.finance]")
+//   4. A blocklist of known-bad symbols
+
+// Known spam symbols (normalized: trimmed + uppercased).
+const SPAM_SYMBOLS = new Set([
+  'MANTRA POS',
+  'AMPAR',
+  'ACHIVX',
+  'BASED',
+  'GT',
+  'MY',
+]);
+
+// Matches domain-like segments such as "name.tld" (e.g. "2base.cfd", "gftpepe.com").
+const DOMAIN_REGEX = /[a-z0-9][a-z0-9-]*\.[a-z]{2,}/i;
+
+export function isSpamToken(symbol: string): boolean {
+  if (!symbol) {
+    return false;
+  }
+
+  const lower = symbol.toLowerCase();
+
+  // 1. Explicit URLs / protocols
+  if (
+    lower.includes('http://') ||
+    lower.includes('https://') ||
+    lower.includes('www.') ||
+    lower.includes('://')
+  ) {
+    return true;
+  }
+
+  // 2. Domain-like patterns
+  if (DOMAIN_REGEX.test(symbol)) {
+    return true;
+  }
+
+  // 3. Bracketed advertising
+  if (symbol.includes('[') || symbol.includes(']')) {
+    return true;
+  }
+
+  // 4. Blocklist match
+  const normalized = symbol.trim().toUpperCase();
+  if (SPAM_SYMBOLS.has(normalized)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## What

Ports the `isSpam` token filter from [reown-swift PR #312](https://github.com/reown-com/reown-swift/pull/312) to the RN CLI wallet so scam/airdrop tokens no longer pollute the balance list.

Scam tokens disguise advertising in their **symbol** field — embedding URLs (`"USD0 [www.usual..]"`, `"ecAVAX - https://invest…"`), domains (`"www.2bas.."`), bracketed promos, or known-bad symbols. These clutter the list and can phish users.

## How

New `isSpamToken(symbol)` (`src/utils/SpamFilter.ts`) mirrors the Swift logic, checking the symbol for:
1. URL substrings — `http://`, `https://`, `www.`, `://`
2. Domain-like patterns — regex `[a-z0-9][a-z0-9-]*\.[a-z]{2,}` (e.g. `2base.cfd`)
3. Brackets — `[` / `]`
4. A normalized blocklist — `MANTRA POS`, `AMPAR`, `ACHIVX`, `BASED`, `GT`, `MY`

`WalletStore.processBalances()` now drops any token that **has an `address`** and a spam symbol. Filtering here covers all chains and merged ERC-20 balances before sort/display. Native rows (ETH/SOL/SUI/TON/TRX) have no `address`, so they're never affected and the existing `MAINNET_NATIVE_TOKENS` logic still guarantees their visibility.

## Testing

- `yarn jest SpamFilter` → 6/6 passing (spam URL/domain/bracket/blocklist cases + legitimate symbols preserved)
- `yarn tsc --noEmit` → clean
- `yarn eslint` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)