### PR TITLE
ci(walletkit): enable associated-domains developer mode for Maestro iOS build

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -261,17 +261,18 @@ runs:
         PB=/usr/libexec/PlistBuddy
         ENT="$WALLET_ROOT/ios/RNWeb3Wallet/RNWeb3Wallet.entitlements"
         KEY=":com.apple.developer.associated-domains"
-        count=$("$PB" -c "Print $KEY" "$ENT" | grep -c 'applinks:')
-        echo "Patching $count associated-domain entries in $ENT"
+        # Walk the array by index until PlistBuddy reports the entry is missing —
+        # avoids pre-counting (which can hard-fail under pipefail) and stays correct
+        # regardless of array order or non-applinks entries (webcredentials:, etc.).
         i=0
-        while [ "$i" -lt "$count" ]; do
-          val=$("$PB" -c "Print $KEY:$i" "$ENT")
+        while val=$("$PB" -c "Print $KEY:$i" "$ENT" 2>/dev/null); do
           case "$val" in
-            *'?mode=developer') ;;
-            *) "$PB" -c "Set $KEY:$i ${val}?mode=developer" "$ENT" ;;
+            applinks:*'?mode=developer') ;;
+            applinks:*) "$PB" -c "Set $KEY:$i ${val}?mode=developer" "$ENT" ;;
           esac
           i=$((i + 1))
         done
+        echo "Patched applinks entries in $ENT:"
         "$PB" -c "Print $KEY" "$ENT"
 
     - name: Build for Simulator
@@ -330,7 +331,7 @@ runs:
           xcrun simctl spawn "$DEVICE_ID" swcutil dl -d "$domain" || true
         done
         sleep 3
-        xcrun simctl spawn "$DEVICE_ID" swcutil show 2>/dev/null | grep -i walletconnect || true
+        xcrun simctl spawn "$DEVICE_ID" swcutil show 2>/dev/null | grep -iE 'walletconnect|reown' || true
 
     # --- Android leg ---
     - name: Install Java 17

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -243,6 +243,37 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pods-${{ github.ref_name }}-
 
+    # Universal Links resolve their app association from the AASA file, which iOS
+    # normally fetches via Apple's CDN. On a fresh simulator that copy can be stale
+    # or missing, so the link opens Safari instead of the wallet. Appending
+    # `?mode=developer` to each associated domain puts it in developer mode, making
+    # the simulator fetch the AASA directly from the origin server and bypass the CDN.
+    # This is patched only here, on the ephemeral Maestro runner — the committed
+    # entitlements file is untouched, so TestFlight builds (which must not ship
+    # dev-mode entitlements) read the clean file in their own separate job.
+    - name: Enable associated-domains developer mode (Maestro build only)
+      if: inputs.platform == 'ios'
+      shell: bash
+      env:
+        WALLET_ROOT: ${{ steps.paths.outputs.wallet_root }}
+      run: |
+        set -euo pipefail
+        PB=/usr/libexec/PlistBuddy
+        ENT="$WALLET_ROOT/ios/RNWeb3Wallet/RNWeb3Wallet.entitlements"
+        KEY=":com.apple.developer.associated-domains"
+        count=$("$PB" -c "Print $KEY" "$ENT" | grep -c 'applinks:')
+        echo "Patching $count associated-domain entries in $ENT"
+        i=0
+        while [ "$i" -lt "$count" ]; do
+          val=$("$PB" -c "Print $KEY:$i" "$ENT")
+          case "$val" in
+            *'?mode=developer') ;;
+            *) "$PB" -c "Set $KEY:$i ${val}?mode=developer" "$ENT" ;;
+          esac
+          i=$((i + 1))
+        done
+        "$PB" -c "Print $KEY" "$ENT"
+
     - name: Build for Simulator
       if: inputs.platform == 'ios'
       uses: maierj/fastlane-action@v3.0.0
@@ -295,7 +326,7 @@ runs:
       shell: bash
       run: |
         xcrun simctl spawn "$DEVICE_ID" swcutil reset || true
-        for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com; do
+        for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com lab.reown.com; do
           xcrun simctl spawn "$DEVICE_ID" swcutil dl -d "$domain" || true
         done
         sleep 3


### PR DESCRIPTION
## What & why

Maestro's iOS e2e suite is intermittently flaky: a Universal Link (a `pay.walletconnect.com` payment link or the `lab.reown.com` connect link) sometimes opens **Safari** instead of the wallet, because iOS resolves the AASA association via Apple's **CDN**, whose copy is often stale/missing on a fresh simulator. This adds a CI-only step that appends `?mode=developer` to every `associated-domains` entry so the simulator fetches each AASA **directly from the origin server**, bypassing the CDN. The patch happens **only on the ephemeral Maestro runner** — the committed `RNWeb3Wallet.entitlements` is untouched, so TestFlight builds (which must not ship dev-mode entitlements, and run in a separate job) keep reading the clean file. The existing `swcutil` AASA-priming step is also extended to cover `lab.reown.com`.

## Why CI-time patching (not editing the file)

The Maestro build and the TestFlight build share the same scheme (`RNWallet-Internal`), Release configuration, and entitlements file, so editing the committed file would leak dev mode into TestFlight — hence the runner-local patch.

```mermaid
flowchart TD
    A[RNWeb3Wallet.entitlements<br/>committed, clean] --> B{Which pipeline?}
    B -->|Maestro e2e job| C[PlistBuddy patch:<br/>append ?mode=developer<br/>to each applinks entry]
    C --> D[build_for_simulator]
    D --> E[Simulator fetches AASA<br/>direct from origin, bypassing CDN]
    E --> F[Universal Link opens wallet ✅]
    B -->|TestFlight release job<br/>separate runner| G[release_testflight<br/>reads clean file]
    G --> H[Ships without dev mode ✅]
```

## Verification
- `ci_e2e_walletkit.yaml` passes `match-git-url`, so the simulator build is signed and entitlements are embedded — the flag takes effect.
- PlistBuddy logic tested on a copy of the real entitlements: all 4 entries patched, idempotent on re-run.
- YAML validated. Real proof is re-running the iOS Maestro job and confirming the link consistently opens the wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)