### PR TITLE
chore: rename Create iOS App placeholder → Create iOS Certificates

### DIFF
--- a/.github/workflows/create-ios-certs.yaml
+++ b/.github/workflows/create-ios-certs.yaml
@@ -1,4 +1,4 @@
-name: Create iOS App
+name: Create iOS Certificates
 
 permissions:
   contents: read


### PR DESCRIPTION
Renames the dispatch placeholder `create-ios-app.yaml` → `create-ios-certs.yaml` (and its display name) to match the real workflow, which only creates **certificates** (the App Store Connect app record is created manually).

Pairs with the rename on `feat/merchant-pos-app`. Keeping the placeholder path in sync avoids leaving an orphaned `create-ios-app.yaml` on `main` after that branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)