### PR TITLE
refactor(rn-cli-wallet): centralize Pay flow result and loading copy

### DIFF
--- a/dapps/pos-app/app/activity.tsx
+++ b/dapps/pos-app/app/activity.tsx
@@ -176,7 +176,7 @@ export default function ActivityScreen() {
 
     return (
       <EmptyState
-        title="No activity yet"
+        title="No payments yet"
         subtitle="Your payments will show up here once you start taking them."
         cta={{
           label: "Start payment",

--- a/wallets/rn_cli_wallet/__tests__/PaymentOptionsModalUtils.test.ts
+++ b/wallets/rn_cli_wallet/__tests__/PaymentOptionsModalUtils.test.ts
@@ -1,0 +1,94 @@
+import {
+  getLoadingContent,
+  getResultContent,
+} from '../src/modals/PaymentOptionsModal/utils';
+
+describe('getResultContent', () => {
+  it('renders the success outcome with the dynamic summary', () => {
+    const content = getResultContent('success', null, {
+      message: "You've paid 5.00 USDT to Acme",
+    });
+
+    expect(content).toMatchObject({
+      title: "You've paid 5.00 USDT to Acme",
+      icon: 'success',
+      iconTestId: 'pay-result-success-icon',
+      actionLabel: 'Done',
+      actionKind: 'close',
+    });
+    expect(content.description).toBeUndefined();
+  });
+
+  it('falls back to the default success title when no summary is given', () => {
+    expect(getResultContent('success', null).title).toBe('Payment confirmed');
+  });
+
+  it('maps insufficient_funds to its title, description, icon and button', () => {
+    const content = getResultContent('error', 'insufficient_funds');
+
+    expect(content).toMatchObject({
+      title: 'Not enough funds in your wallet',
+      icon: 'coins',
+      iconTestId: 'pay-result-insufficient-funds-icon',
+      actionLabel: 'Got it',
+      actionKind: 'close',
+    });
+    expect(content.description).toContain('Add funds, or pay');
+  });
+
+  it('routes expired and cancelled errors to the scan-QR action', () => {
+    expect(getResultContent('error', 'expired')).toMatchObject({
+      iconTestId: 'pay-result-expired-icon',
+      actionLabel: 'Scan a new QR code',
+      actionKind: 'scanQR',
+    });
+    expect(getResultContent('error', 'cancelled')).toMatchObject({
+      iconTestId: 'pay-result-cancelled-icon',
+      actionLabel: 'Scan a new QR code',
+      actionKind: 'scanQR',
+    });
+  });
+
+  it('uses the raw error message as the generic description, then a default', () => {
+    expect(
+      getResultContent('error', 'generic', { message: 'boom' }).description,
+    ).toBe('boom');
+    expect(getResultContent('error', 'generic').description).toContain(
+      'No funds were moved',
+    );
+  });
+
+  it('treats an error with no classified type as generic', () => {
+    expect(getResultContent('error', null)).toMatchObject({
+      title: 'Payment didn’t go through',
+      iconTestId: 'pay-result-error-icon',
+      actionKind: 'close',
+    });
+  });
+});
+
+describe('getLoadingContent', () => {
+  it('returns the step default with no note when nothing is being set up', () => {
+    expect(getLoadingContent('loading')).toEqual({
+      message: 'Preparing your payment…',
+    });
+    expect(getLoadingContent('confirming')).toEqual({
+      message: 'Confirming your payment…',
+    });
+  });
+
+  it('returns the token-setup message and note when a token is being set up', () => {
+    expect(getLoadingContent('confirming', { setupTokenSymbol: 'USDT' })).toEqual(
+      {
+        message: 'Setting up USDT',
+        note: 'This usually takes a few seconds. Future USDT payments will skip this step.',
+      },
+    );
+  });
+
+  it('lets the setup token take precedence over the step default', () => {
+    expect(
+      getLoadingContent('loading', { setupTokenSymbol: 'USDC' }).message,
+    ).toBe('Setting up USDC');
+  });
+});

--- a/wallets/rn_cli_wallet/__tests__/PaymentOptionsModalUtils.test.ts
+++ b/wallets/rn_cli_wallet/__tests__/PaymentOptionsModalUtils.test.ts
@@ -58,6 +58,18 @@ describe('getResultContent', () => {
     );
   });
 
+  it('maps not_found to its title, description and close action', () => {
+    const content = getResultContent('error', 'not_found');
+
+    expect(content).toMatchObject({
+      title: 'Payment request not found',
+      iconTestId: 'pay-result-error-icon',
+      actionLabel: 'Close',
+      actionKind: 'close',
+    });
+    expect(content.description).toContain('isn’t valid');
+  });
+
   it('treats an error with no classified type as generic', () => {
     expect(getResultContent('error', null)).toMatchObject({
       title: 'Payment didn’t go through',

--- a/wallets/rn_cli_wallet/__tests__/PaymentStore.test.ts
+++ b/wallets/rn_cli_wallet/__tests__/PaymentStore.test.ts
@@ -445,7 +445,7 @@ describe('PaymentStore', () => {
 
   it('keeps the default processing message for single-step typed-data payments', async () => {
     mockedSignTypedData.mockImplementation(async () => {
-      expect(PaymentStore.state.loadingMessage).toBeNull();
+      expect(PaymentStore.state.setupTokenSymbol).toBeNull();
       return '0xsigned';
     });
 
@@ -479,8 +479,7 @@ describe('PaymentStore', () => {
       () => deferredActions.promise,
     );
     mockedSendTransactionWithFreshFees.mockImplementation(async () => {
-      expect(PaymentStore.state.loadingMessage).toBeNull();
-      expect(PaymentStore.state.loadingNote).toBeNull();
+      expect(PaymentStore.state.setupTokenSymbol).toBeNull();
       return {
         hash: '0xhash',
         wait: jest.fn(),
@@ -505,8 +504,7 @@ describe('PaymentStore', () => {
     const approvePromise = PaymentStore.approvePayment();
 
     expect(PaymentStore.state.step).toBe('confirming');
-    expect(PaymentStore.state.loadingMessage).toBeNull();
-    expect(PaymentStore.state.loadingNote).toBeNull();
+    expect(PaymentStore.state.setupTokenSymbol).toBeNull();
 
     deferredActions.resolve([
       createAction(EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION, [
@@ -543,7 +541,7 @@ describe('PaymentStore', () => {
     ]);
 
     mockedSignTypedData.mockImplementation(async () => {
-      expect(PaymentStore.state.loadingMessage).toBeNull();
+      expect(PaymentStore.state.setupTokenSymbol).toBeNull();
       return '0xsigned';
     });
 
@@ -610,12 +608,7 @@ describe('PaymentStore', () => {
     const approvePromise = PaymentStore.approvePayment();
 
     expect(PaymentStore.state.step).toBe('confirming');
-    expect(PaymentStore.state.loadingMessage).toBe(
-      'Setting up USDT',
-    );
-    expect(PaymentStore.state.loadingNote).toBe(
-      'This usually takes a few seconds. Future USDT payments will skip this step.',
-    );
+    expect(PaymentStore.state.setupTokenSymbol).toBe('USDT');
 
     deferredActions.resolve([
       createAction(EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION, [

--- a/wallets/rn_cli_wallet/src/hooks/usePairing.ts
+++ b/wallets/rn_cli_wallet/src/hooks/usePairing.ts
@@ -12,9 +12,7 @@ export { isPaymentLink };
 
 export function usePairing() {
   const handlePaymentLink = useCallback(async (paymentLink: string) => {
-    PaymentStore.startPayment({
-      loadingMessage: 'Preparing your payment...',
-    });
+    PaymentStore.startPayment();
     ModalStore.open('PaymentOptionsModal');
 
     await SettingsStore.state.initPromise;

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ResultView.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/ResultView.tsx
@@ -9,13 +9,15 @@ import WarningCircle from '@/assets/WarningCircle';
 import { haptics } from '@/utils/haptics';
 import { Spacing } from '@/utils/ThemeUtil';
 
-import type { ErrorType } from './utils';
+import type { ErrorType, ResultIcon } from './utils';
 import {
   arePayModalAnimationsEnabled,
-  getErrorTitle,
+  getResultContent,
   LOTTIE_ICON_SIZE,
   PAY_STATUS_LAYOUT,
 } from './utils';
+
+const ERROR_ICON_COLOR = '#0988F0';
 
 const getResultButtonTestId = (
   isSuccess: boolean,
@@ -23,15 +25,38 @@ const getResultButtonTestId = (
 ) =>
   `pay-button-result-action-${isSuccess ? 'success' : errorType || 'generic'}`;
 
-const getActionButtonText = (
-  isSuccess: boolean,
-  errorType?: ErrorType | null,
-) => {
-  if (isSuccess) return 'Done';
-  if (errorType === 'insufficient_funds') return 'Got it';
-  if (errorType === 'expired' || errorType === 'cancelled')
-    return 'Scan a new QR code';
-  return 'Close';
+const renderIcon = (icon: ResultIcon, testID: string) => {
+  switch (icon) {
+    case 'success':
+      return (
+        <LottieView
+          source={require('@/assets/lottie/Success.json')}
+          autoPlay={arePayModalAnimationsEnabled}
+          loop={false}
+          progress={arePayModalAnimationsEnabled ? undefined : 1}
+          style={styles.successAnimation}
+          testID={testID}
+        />
+      );
+    case 'coins':
+      return (
+        <CoinStack
+          width={40}
+          height={40}
+          fill={ERROR_ICON_COLOR}
+          testID={testID}
+        />
+      );
+    case 'warning':
+      return (
+        <WarningCircle
+          width={40}
+          height={40}
+          fill={ERROR_ICON_COLOR}
+          testID={testID}
+        />
+      );
+  }
 };
 
 interface ResultViewProps {
@@ -58,107 +83,9 @@ export function ResultView({
   }, [status]);
 
   const isSuccess = status === 'success';
-  const defaultMessage = isSuccess
-    ? 'Payment confirmed'
-    : 'Payment didn’t go through. No funds were moved. Try again, or pay with a different asset.';
-
-  const renderIcon = () => {
-    if (isSuccess) {
-      return (
-        <LottieView
-          source={require('@/assets/lottie/Success.json')}
-          autoPlay={arePayModalAnimationsEnabled}
-          loop={false}
-          progress={arePayModalAnimationsEnabled ? undefined : 1}
-          style={styles.successAnimation}
-          testID="pay-result-success-icon"
-        />
-      );
-    }
-
-    const iconColor = '#0988F0';
-
-    switch (errorType) {
-      case 'insufficient_funds':
-        return (
-          <CoinStack
-            width={40}
-            height={40}
-            fill={iconColor}
-            testID="pay-result-insufficient-funds-icon"
-          />
-        );
-      case 'expired':
-        return (
-          <WarningCircle
-            width={40}
-            height={40}
-            fill={iconColor}
-            testID="pay-result-expired-icon"
-          />
-        );
-      case 'cancelled':
-        return (
-          <WarningCircle
-            width={40}
-            height={40}
-            fill={iconColor}
-            testID="pay-result-cancelled-icon"
-          />
-        );
-      case 'not_found':
-      case 'generic':
-      default:
-        return (
-          <WarningCircle
-            width={40}
-            height={40}
-            fill={iconColor}
-            testID="pay-result-error-icon"
-          />
-        );
-    }
-  };
-
-  const renderTitle = () => {
-    if (isSuccess) {
-      return (
-        <Text
-          variant="h6-400"
-          color="text-primary"
-          center
-          numberOfLines={2}
-          testID="pay-result-title"
-        >
-          {message || defaultMessage}
-        </Text>
-      );
-    }
-
-    if (!errorType) {
-      return (
-        <Text
-          variant="h6-400"
-          color="text-primary"
-          center
-          testID="pay-result-title"
-        >
-          {message || defaultMessage}
-        </Text>
-      );
-    }
-
-    return (
-      <Text
-        variant="h6-400"
-        color="text-primary"
-        center
-        testID="pay-result-title"
-      >
-        {getErrorTitle(errorType)}
-      </Text>
-    );
-  };
+  const content = getResultContent(status, errorType ?? null, { message });
+  const onPress =
+    content.actionKind === 'scanQR' && onScanQR ? onScanQR : onClose;
 
   return (
     <>
@@ -166,11 +93,19 @@ export function ResultView({
         style={isSuccess ? styles.iconArea : styles.iconAreaCompact}
         testID="pay-result-container"
       >
-        {renderIcon()}
+        {renderIcon(content.icon, content.iconTestId)}
       </View>
       <View style={styles.textArea}>
-        {renderTitle()}
-        {!isSuccess && (
+        <Text
+          variant="h6-400"
+          color="text-primary"
+          center
+          numberOfLines={isSuccess ? 2 : undefined}
+          testID="pay-result-title"
+        >
+          {content.title}
+        </Text>
+        {content.description && (
           <Text
             variant="lg-400"
             color="text-tertiary"
@@ -178,21 +113,17 @@ export function ResultView({
             numberOfLines={3}
             center
           >
-            {message || defaultMessage}
+            {content.description}
           </Text>
         )}
       </View>
       <View style={styles.footerContainer}>
         <ActionButton
-          onPress={
-            (errorType === 'expired' || errorType === 'cancelled') && onScanQR
-              ? onScanQR
-              : onClose
-          }
+          onPress={onPress}
           fullWidth
           testID={getResultButtonTestId(isSuccess, errorType)}
         >
-          {getActionButtonText(isSuccess, errorType)}
+          {content.actionLabel}
         </ActionButton>
       </View>
     </>

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/index.tsx
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/index.tsx
@@ -16,7 +16,7 @@ import { InfoExplainerView } from './InfoExplainerView';
 import { ExpiryWarningView } from './ExpiryWarningView';
 import { ResultView } from './ResultView';
 import { ViewWrapper } from './ViewWrapper';
-import { detectErrorType, getErrorMessage } from './utils';
+import { detectErrorType, getLoadingContent } from './utils';
 import { GasFeeView } from './GasFeeView';
 import { requiresApproval } from '@/utils/PaymentUtil';
 
@@ -42,7 +42,7 @@ export default function PaymentOptionsModal() {
         const errorType = detectErrorType(snap.errorMessage);
         PaymentStore.setResult({
           status: 'error',
-          message: getErrorMessage(errorType, snap.errorMessage),
+          message: snap.errorMessage,
           errorType,
         });
         return;
@@ -65,7 +65,6 @@ export default function PaymentOptionsModal() {
         PaymentStore.setResult({
           status: 'error',
           errorType: 'insufficient_funds',
-          message: getErrorMessage('insufficient_funds'),
         });
         return;
       }
@@ -156,7 +155,7 @@ export default function PaymentOptionsModal() {
     const errorType = detectErrorType(error);
     PaymentStore.setResult({
       status: 'error',
-      message: getErrorMessage(errorType, error),
+      message: error,
       errorType,
     });
   }, []);
@@ -184,7 +183,6 @@ export default function PaymentOptionsModal() {
     PaymentStore.setResult({
       status: 'error',
       errorType: 'expired',
-      message: getErrorMessage('expired'),
     });
   }, []);
 
@@ -240,7 +238,6 @@ export default function PaymentOptionsModal() {
         PaymentStore.setResult({
           status: 'error',
           errorType: 'insufficient_funds',
-          message: getErrorMessage('insufficient_funds'),
         });
         return;
       }
@@ -262,7 +259,11 @@ export default function PaymentOptionsModal() {
         return (
           <LoadingView
             variant="spinner"
-            message={snap.loadingMessage || 'Preparing your payment…'}
+            message={
+              getLoadingContent('loading', {
+                setupTokenSymbol: snap.setupTokenSymbol,
+              }).message
+            }
           />
         );
 
@@ -340,13 +341,14 @@ export default function PaymentOptionsModal() {
         );
       }
 
-      case 'confirming':
+      case 'confirming': {
+        const confirming = getLoadingContent('confirming', {
+          setupTokenSymbol: snap.setupTokenSymbol,
+        });
         return (
-          <LoadingView
-            message={snap.loadingMessage || 'Confirming your payment…'}
-            note={snap.loadingNote || undefined}
-          />
+          <LoadingView message={confirming.message} note={confirming.note} />
         );
+      }
 
       case 'expiryWarning':
         if (!snap.expiresAt) return null;
@@ -370,7 +372,7 @@ export default function PaymentOptionsModal() {
         );
 
       default:
-        return <LoadingView message="Loading..." />;
+        return <LoadingView message="Loading…" />;
     }
   }, [
     snap.step,
@@ -378,8 +380,7 @@ export default function PaymentOptionsModal() {
     snap.resultStatus,
     snap.resultErrorType,
     snap.resultMessage,
-    snap.loadingMessage,
-    snap.loadingNote,
+    snap.setupTokenSymbol,
     snap.paymentOptions,
     snap.optionFeeEstimatesById,
     snap.optionFeeEstimateStatusById,

--- a/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/utils.ts
+++ b/wallets/rn_cli_wallet/src/modals/PaymentOptionsModal/utils.ts
@@ -138,14 +138,27 @@ export function getCurrencySymbol(currencyCode?: string): string {
   return CURRENCY_SYMBOLS[currencyCode.toUpperCase()] || currencyCode;
 }
 
-// ----- Error Type Helpers -----
-
 export type ErrorType =
   | 'insufficient_funds'
   | 'expired'
   | 'cancelled'
   | 'not_found'
   | 'generic';
+
+export type ResultIcon = 'success' | 'coins' | 'warning';
+export type ResultActionKind = 'close' | 'scanQR';
+
+export interface ResultContent {
+  title: string;
+  // Errors show a secondary description line; success shows title only.
+  description?: string;
+  icon: ResultIcon;
+  iconTestId: string;
+  actionLabel: string;
+  actionKind: ResultActionKind;
+}
+
+const SUCCESS_DEFAULT_TITLE = 'Payment confirmed';
 
 export function detectErrorType(message: string): ErrorType {
   const lowerMsg = message.toLowerCase();
@@ -168,22 +181,22 @@ export function detectErrorType(message: string): ErrorType {
   return 'generic';
 }
 
-export function getErrorTitle(errorType: ErrorType): string {
+function getErrorTitle(errorType: ErrorType): string {
   switch (errorType) {
     case 'insufficient_funds':
       return 'Not enough funds in your wallet';
     case 'expired':
-      return 'Payment expired';
+      return 'Payment request expired';
     case 'cancelled':
-      return 'Payment cancelled';
+      return 'Payment request cancelled';
     case 'not_found':
-      return 'Payment not found';
+      return 'Payment request not found';
     case 'generic':
       return 'Payment didn’t go through';
   }
 }
 
-export function getErrorMessage(
+function getErrorDescription(
   errorType: ErrorType,
   originalMessage?: string,
 ): string {
@@ -199,7 +212,102 @@ export function getErrorMessage(
     case 'generic':
       return (
         originalMessage ||
-        'The network couldn’t complete this payment. No funds were moved. Try again, or pay with a different asset.'
+        'No funds were moved. Try again, or pay with a different asset from checkout.'
       );
   }
+}
+
+function getErrorIcon(errorType: ErrorType): {
+  icon: ResultIcon;
+  testId: string;
+} {
+  switch (errorType) {
+    case 'insufficient_funds':
+      return { icon: 'coins', testId: 'pay-result-insufficient-funds-icon' };
+    case 'expired':
+      return { icon: 'warning', testId: 'pay-result-expired-icon' };
+    case 'cancelled':
+      return { icon: 'warning', testId: 'pay-result-cancelled-icon' };
+    case 'not_found':
+    case 'generic':
+      return { icon: 'warning', testId: 'pay-result-error-icon' };
+  }
+}
+
+function getErrorActionLabel(errorType: ErrorType): string {
+  switch (errorType) {
+    case 'insufficient_funds':
+      return 'Got it';
+    case 'expired':
+    case 'cancelled':
+      return 'Scan a new QR code';
+    case 'not_found':
+    case 'generic':
+      return 'Close';
+  }
+}
+
+/**
+ * Resolves the full presentation for a result screen.
+ *
+ * @param status     'success' or 'error'.
+ * @param errorType  The classified error (ignored for success).
+ * @param ctx.message Dynamic context — the success summary on success, or the
+ *                    raw error message used as the generic-error fallback.
+ */
+export function getResultContent(
+  status: 'success' | 'error',
+  errorType: ErrorType | null,
+  ctx?: { message?: string },
+): ResultContent {
+  if (status === 'success') {
+    return {
+      title: ctx?.message || SUCCESS_DEFAULT_TITLE,
+      icon: 'success',
+      iconTestId: 'pay-result-success-icon',
+      actionLabel: 'Done',
+      actionKind: 'close',
+    };
+  }
+
+  const type = errorType ?? 'generic';
+  const { icon, testId } = getErrorIcon(type);
+
+  return {
+    title: getErrorTitle(type),
+    description: getErrorDescription(type, ctx?.message),
+    icon,
+    iconTestId: testId,
+    actionLabel: getErrorActionLabel(type),
+    actionKind: type === 'expired' || type === 'cancelled' ? 'scanQR' : 'close',
+  };
+}
+
+// Steps that render the LoadingView. Token setup happens during 'confirming'.
+export type LoadingStep = 'loading' | 'confirming';
+
+export interface LoadingContent {
+  message: string;
+  // Secondary line shown only while setting up a token for the first time.
+  note?: string;
+}
+
+export function getLoadingContent(
+  step: LoadingStep,
+  ctx?: { setupTokenSymbol?: string | null },
+): LoadingContent {
+  const symbol = ctx?.setupTokenSymbol;
+  if (symbol) {
+    return {
+      message: `Setting up ${symbol}`,
+      note: `This usually takes a few seconds. Future ${symbol} payments will skip this step.`,
+    };
+  }
+
+  return {
+    message:
+      step === 'confirming'
+        ? 'Confirming your payment…'
+        : 'Preparing your payment…',
+  };
 }

--- a/wallets/rn_cli_wallet/src/modals/SessionSignCantonModal.tsx
+++ b/wallets/rn_cli_wallet/src/modals/SessionSignCantonModal.tsx
@@ -52,7 +52,7 @@ export default function SessionSignCantonModal() {
           topic,
           response: errorResponse,
         });
-      } catch (_) {
+      } catch {
         // best effort
       }
       LogStore.error(

--- a/wallets/rn_cli_wallet/src/navigators/RootStackNavigator.tsx
+++ b/wallets/rn_cli_wallet/src/navigators/RootStackNavigator.tsx
@@ -37,7 +37,7 @@ export function RootStackNavigator() {
       <StackNavigator.Screen
         options={{
           headerShown: true,
-          header: () => <Header />,
+          header: Header,
         }}
         name="Home"
         component={HomeTabNavigator}

--- a/wallets/rn_cli_wallet/src/screens/Connections/components/Sessions.tsx
+++ b/wallets/rn_cli_wallet/src/screens/Connections/components/Sessions.tsx
@@ -23,7 +23,7 @@ function Sessions() {
           No connected apps yet
         </Text>
         <Text variant="lg-400" color="text-secondary" center>
-          Scan a WalletConnect QR code to get started.
+          Apps you connect will show up here. Scan a QR code to add your first one.
         </Text>
         <ActionButton
           style={styles.emptyStateButton}

--- a/wallets/rn_cli_wallet/src/store/PaymentStore.ts
+++ b/wallets/rn_cli_wallet/src/store/PaymentStore.ts
@@ -181,11 +181,13 @@ const PaymentStore = {
 
   setError(errorMessage: string) {
     const errorType = detectErrorType(errorMessage);
-    state.errorMessage = errorMessage;
-    state.setupTokenSymbol = null;
     state.resultStatus = 'error';
     state.resultMessage = errorMessage;
     state.resultErrorType = errorType;
+    // Clear the transient loading-phase errorMessage so it can't re-trigger the
+    // error branch in resolveLoadingStep, consistent with setResult.
+    state.errorMessage = null;
+    state.setupTokenSymbol = null;
     state.step = 'result';
   },
 

--- a/wallets/rn_cli_wallet/src/store/PaymentStore.ts
+++ b/wallets/rn_cli_wallet/src/store/PaymentStore.ts
@@ -15,7 +15,6 @@ import { storage } from '@/utils/storage';
 import type { OptionFeeEstimateStatus, Step } from '@/utils/TypesUtil';
 import {
   detectErrorType,
-  getErrorMessage,
   formatAmount,
 } from '@/modals/PaymentOptionsModal/utils';
 import type { ErrorType } from '@/modals/PaymentOptionsModal/utils';
@@ -32,8 +31,7 @@ import { getApprovalAction, shouldShowSetupLoader } from '@/utils/PaymentUtil';
 
 interface PaymentState {
   paymentOptions: PaymentOptionsResponse | null;
-  loadingMessage: string | null;
-  loadingNote: string | null;
+  setupTokenSymbol: string | null;
   errorMessage: string | null;
   step: Step;
   previousStep: Step | null;
@@ -48,15 +46,13 @@ interface PaymentState {
 }
 
 const PAY_EXPIRY_GUARD_MS = 10_000;
-const FAILED_CONFIRMATION_MESSAGE = 'The payment could not be confirmed.';
 const PAY_LAST_TOKEN_UNIT_KEY = 'PAY_LAST_TOKEN_UNIT';
 const DEFAULT_FIAT_CURRENCY = 'USD';
 
 function createInitialState(): PaymentState {
   return {
     paymentOptions: null,
-    loadingMessage: null,
-    loadingNote: null,
+    setupTokenSymbol: null,
     errorMessage: null,
     step: 'loading',
     previousStep: null,
@@ -108,7 +104,6 @@ function setPaymentResultFromConfirmStatus({
     PaymentStore.setResult({
       status: 'error',
       errorType: 'expired',
-      message: getErrorMessage('expired'),
     });
     return;
   }
@@ -117,7 +112,6 @@ function setPaymentResultFromConfirmStatus({
     PaymentStore.setResult({
       status: 'error',
       errorType: 'cancelled',
-      message: getErrorMessage('cancelled'),
     });
     return;
   }
@@ -126,7 +120,6 @@ function setPaymentResultFromConfirmStatus({
     PaymentStore.setResult({
       status: 'error',
       errorType: 'generic',
-      message: FAILED_CONFIRMATION_MESSAGE,
     });
     return;
   }
@@ -144,18 +137,18 @@ function setPaymentResultFromConfirmStatus({
   PaymentStore.setResult({
     status: 'error',
     errorType: 'generic',
-    message: FAILED_CONFIRMATION_MESSAGE,
   });
 }
 
 const PaymentStore = {
   state,
 
-  startPayment(params: {
-    paymentOptions?: PaymentOptionsResponse;
-    loadingMessage?: string;
-    errorMessage?: string;
-  }) {
+  startPayment(
+    params: {
+      paymentOptions?: PaymentOptionsResponse;
+      errorMessage?: string;
+    } = {},
+  ) {
     PaymentStore.clearExpiryTimer();
     paymentActionsRequestSeq += 1;
     optionFeeEstimateRequestSeq += 1;
@@ -163,14 +156,12 @@ const PaymentStore = {
     if (params.paymentOptions) {
       state.paymentOptions = ref(params.paymentOptions);
     }
-    state.loadingMessage = params.loadingMessage ?? null;
     state.errorMessage = params.errorMessage ?? null;
   },
 
   setPaymentOptions(options: PaymentOptionsResponse) {
     state.paymentOptions = ref(options);
-    state.loadingMessage = null;
-    state.loadingNote = null;
+    state.setupTokenSymbol = null;
     state.errorMessage = null;
     state.resultErrorType = null;
     state.optionFeeEstimatesById = {};
@@ -191,10 +182,9 @@ const PaymentStore = {
   setError(errorMessage: string) {
     const errorType = detectErrorType(errorMessage);
     state.errorMessage = errorMessage;
-    state.loadingMessage = null;
-    state.loadingNote = null;
+    state.setupTokenSymbol = null;
     state.resultStatus = 'error';
-    state.resultMessage = getErrorMessage(errorType, errorMessage);
+    state.resultMessage = errorMessage;
     state.resultErrorType = errorType;
     state.step = 'result';
   },
@@ -216,15 +206,16 @@ const PaymentStore = {
 
   setResult(payload: {
     status: 'success' | 'error';
-    message: string;
+    // Optional dynamic context — success summary, or raw error message. Result
+    // copy itself is resolved in the view via getResultContent.
+    message?: string;
     errorType?: ErrorType;
   }) {
     state.resultStatus = payload.status;
-    state.resultMessage = payload.message;
+    state.resultMessage = payload.message ?? '';
     state.resultErrorType = payload.errorType ?? null;
     state.errorMessage = null;
-    state.loadingMessage = null;
-    state.loadingNote = null;
+    state.setupTokenSymbol = null;
     state.step = 'result';
   },
 
@@ -487,7 +478,6 @@ const PaymentStore = {
       PaymentStore.setResult({
         status: 'error',
         errorType: 'expired',
-        message: getErrorMessage('expired'),
       });
       return;
     }
@@ -498,13 +488,7 @@ const PaymentStore = {
     );
 
     state.step = 'confirming';
-    if (showInitialSetupLoader) {
-      state.loadingMessage = `Setting up ${tokenSymbol}`;
-      state.loadingNote = `This usually takes a few seconds. Future ${tokenSymbol} payments will skip this step.`;
-    } else {
-      state.loadingMessage = null;
-      state.loadingNote = null;
-    }
+    state.setupTokenSymbol = showInitialSetupLoader ? tokenSymbol : null;
 
     try {
       const payClient = walletKit?.pay;
@@ -531,13 +515,10 @@ const PaymentStore = {
           throw new Error(`Payment action ${stepLabel} is missing walletRpc`);
         }
 
-        if (showSetupLoader && approvalAction && action === approvalAction) {
-          state.loadingMessage = `Setting up ${tokenSymbol}`;
-          state.loadingNote = `This usually takes a few seconds. Future ${tokenSymbol} payments will skip this step.`;
-        } else {
-          state.loadingMessage = null;
-          state.loadingNote = null;
-        }
+        state.setupTokenSymbol =
+          showSetupLoader && approvalAction && action === approvalAction
+            ? tokenSymbol
+            : null;
 
         LogStore.log(
           'Executing payment action',
@@ -803,7 +784,7 @@ const PaymentStore = {
       PaymentStore.setResult({
         status: 'error',
         errorType,
-        message: getErrorMessage(errorType, errorMessage),
+        message: errorMessage,
       });
     }
   },


### PR DESCRIPTION
## Summary

The WalletConnect Pay flow had its result and loading copy (titles, descriptions, icons, button labels, loading messages) scattered across the view, the store, and a utils file — with the `message` field overloaded and several strings duplicated and already drifting apart. This centralizes all of it behind single helpers in `utils.ts`, so the store carries only **semantic state** and the view derives all presentation from one place.

- **`getResultContent(status, errorType, ctx)`** — one descriptor (`title`, `description`, `icon`, `iconTestId`, `actionLabel`, `actionKind`) for every result outcome. `ResultView` is now logic-free; removed `getActionButtonText`, the per-type `renderIcon` switch, and the overloaded title/description logic.
- **`getLoadingContent(step, ctx)`** — one source for loading copy. The store's `loadingMessage`/`loadingNote` are replaced by a single semantic field `setupTokenSymbol`, collapsing the duplicated "Setting up {token}" pair.
- Removed the **three drifting "generic failure" strings** (`FAILED_CONFIRMATION_MESSAGE`, an inline `defaultMessage`, and `getErrorMessage('generic')`) down to one, and dropped the redundant `loadingMessage` param from `startPayment`.
- Added `PaymentOptionsModalUtils.test.ts` locking the centralized copy; updated `PaymentStore.test.ts` to assert the semantic `setupTokenSymbol`. All existing testIDs are preserved.
- Also folds in minor empty-state/copy and lint tweaks in `pos-app`, `Sessions`, `SessionSignCantonModal`, and `RootStackNavigator`.

## Data flow

```mermaid
flowchart LR
    Store["PaymentStore<br/>(semantic state:<br/>resultStatus, resultErrorType,<br/>resultMessage, setupTokenSymbol)"]
    Result["getResultContent()"]
    Loading["getLoadingContent()"]
    View["ResultView / LoadingView<br/>(presentation only)"]
    Store --> Result --> View
    Store --> Loading --> View
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)