### PR TITLE
ci(walletkit): revert applinks ?mode=developer patch for Maestro iOS

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -399,14 +399,13 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions PR #93 (fix/maestro-ios-universal-link-retry):
-    # retries the iOS universal-link open until pay-merchant-info is visible.
-    # Re-pin to master once that PR merges.
+    # Pinned to WalletConnect/actions master (incl. PR #93): retries the iOS
+    # universal-link open until pay-merchant-info is visible.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@6e17edbaac3da5bf7d8015d8146860034ea36f39
+      uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@6e17edbaac3da5bf7d8015d8146860034ea36f39
+      uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -399,8 +399,7 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions master (incl. PR #93): retries the iOS
-    # universal-link open until pay-merchant-info is visible.
+    # Pinned to WalletConnect/actions master
     - name: Copy shared Pay test flows
       uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -239,38 +239,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pods-${{ github.ref_name }}-
 
-    # Universal Links resolve their app association from the AASA file, which iOS
-    # normally fetches via Apple's CDN. On a fresh simulator that copy can be stale
-    # or missing, so the link opens Safari instead of the wallet. Appending
-    # `?mode=developer` to each associated domain puts it in developer mode, making
-    # the simulator fetch the AASA directly from the origin server and bypass the CDN.
-    # This is patched only here, on the ephemeral Maestro runner — the committed
-    # entitlements file is untouched, so TestFlight builds (which must not ship
-    # dev-mode entitlements) read the clean file in their own separate job.
-    - name: Enable associated-domains developer mode (Maestro build only)
-      if: inputs.platform == 'ios'
-      shell: bash
-      env:
-        WALLET_ROOT: ${{ steps.paths.outputs.wallet_root }}
-      run: |
-        set -euo pipefail
-        PB=/usr/libexec/PlistBuddy
-        ENT="$WALLET_ROOT/ios/RNWeb3Wallet/RNWeb3Wallet.entitlements"
-        KEY=":com.apple.developer.associated-domains"
-        # Walk the array by index until PlistBuddy reports the entry is missing —
-        # avoids pre-counting (which can hard-fail under pipefail) and stays correct
-        # regardless of array order or non-applinks entries (webcredentials:, etc.).
-        i=0
-        while val=$("$PB" -c "Print $KEY:$i" "$ENT" 2>/dev/null); do
-          case "$val" in
-            applinks:*'?mode=developer') ;;
-            applinks:*) "$PB" -c "Set $KEY:$i ${val}?mode=developer" "$ENT" ;;
-          esac
-          i=$((i + 1))
-        done
-        echo "Patched applinks entries in $ENT:"
-        "$PB" -c "Print $KEY" "$ENT"
-
     - name: Build for Simulator
       if: inputs.platform == 'ios'
       uses: maierj/fastlane-action@v3.0.0
@@ -315,8 +283,8 @@ runs:
         xcrun simctl bootstatus "$DEVICE_ID" -b
         # Clear stale Shared Web Credentials / associated-domains state on the fresh
         # boot BEFORE the app is installed, so the install-time applinks binding isn't
-        # wiped by a later reset (which would force a racy dev-mode AASA re-fetch and
-        # leave the Universal Link unresolved → openurl falls back to Safari).
+        # wiped by a later reset (which would force a racy AASA re-fetch and leave the
+        # Universal Link unresolved → openurl falls back to Safari).
         xcrun simctl spawn "$DEVICE_ID" swcutil reset || true
         # Disable UIKit animations to reduce Maestro timing flakiness
         xcrun simctl spawn "$DEVICE_ID" defaults write com.apple.UIKit UIAnimationDragCoefficient 0 || true

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -399,11 +399,14 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     # --- Common: Maestro setup + run ---
+    # Pinned to WalletConnect/actions PR #93 (fix/maestro-ios-universal-link-retry):
+    # retries the iOS universal-link open until pay-merchant-info is visible.
+    # Re-pin to master once that PR merges.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
+      uses: WalletConnect/actions/maestro/pay-tests@6e17edbaac3da5bf7d8015d8146860034ea36f39
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d
+      uses: WalletConnect/actions/maestro/setup@6e17edbaac3da5bf7d8015d8146860034ea36f39
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'


### PR DESCRIPTION
## What

Removes the CI step that patched `?mode=developer` onto each `applinks:` associated domain in the wallet's entitlements on the Maestro iOS runner.

## Why

The Universal Link E2E test ("WalletConnect Pay - Single Option No KYC (Universal Link)") keeps flaking — it opens Safari instead of the wallet. Digging into the `swcd` syslog from run [27032183526](https://github.com/reown-com/react-native-examples/actions/runs/27032183526/job/79787071027):

- The AASA **does** download and approve correctly (HTTP 200, `sa = approved, patternCount = 1`). Entitlements, domains, and the AASA file are all fine.
- But `?mode=developer` tells `swcd` never to cache/trust the AASA. Its recheck date is pinned to the zero date (`Sat Dec 30 … 0000`), i.e. permanently overdue — so it re-fetches **~every minute** (13 fetches/domain in a 10-min run). Apple's own non-dev entries, by contrast, recheck ~5 days out.
- Each re-fetch transiently drops the entry to `sa = unspecified` with no patterns. The failing tap (18:38:23) landed in exactly such a window:
  ```
  swcd  Found entry { … d = pay.walletconnect.com?mode=developer, sa = unspecified } matching inputs { … d = pay.walletconnect.com }
  swcd  Entry { … sa = unspecified } did not have any patterns to match against
  ```
  → no app claims the URL → Safari handles it → `pay-merchant-info` never appears → assertion fails.

So dev mode doesn't fix the race; it converts a one-time post-install window into a perpetual one. Reverting to the normal **CDN route** gives a stable verdict once verified (the CDN serves the AASA for all four domains).

## This does not fully fix the flake on its own

Maestro reinstalls the app on **every** flow (`clearState` on iOS = uninstall+reinstall — **10 cycles** in this run). Each reinstall re-registers the association and triggers a fresh verification right before that flow's tap, so a per-flow race remains in both CDN and dev mode. The deeplink flow tapped ~40s after its own reinstall (18:37:43 → 18:38:23).

The durable fix — **retry the `openLink` until the wallet screen appears** — has to live in the deeplink flow yaml, which is in the `WalletConnect/actions` repo. That will be handled separately there.

## Draft because

This is the first half of a two-part fix; pairing it with the flow-side retry in the actions repo. Opening as draft for visibility / discussion while that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)