### PR TITLE
ci(walletkit): run scheduled Maestro pay tests every 6 hours

### DIFF
--- a/.github/workflows/ci_e2e_walletkit.yaml
+++ b/.github/workflows/ci_e2e_walletkit.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 * * * *' # Every hour, UTC
+    - cron: '0 */6 * * *' # Every 6 hours, UTC
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

Reduces the frequency of the scheduled WalletKit Maestro `pay` E2E tests from hourly to every 6 hours, cutting CI usage while still providing regular coverage. Only the `schedule` cron is changed; `pull_request` and `workflow_dispatch` triggers are untouched.

```mermaid
gantt
    title Scheduled Maestro pay runs (UTC)
    dateFormat HH:mm
    axisFormat %H:%M
    section Before (hourly)
    runs :00:00, 24h
    section After (every 6h)
    00:00 :milestone, 00:00, 0h
    06:00 :milestone, 06:00, 0h
    12:00 :milestone, 12:00, 0h
    18:00 :milestone, 18:00, 0h
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)