### PR TITLE
ci(walletkit-maestro): bump WalletConnect/actions pin to pick up timeout bumps

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -401,10 +401,10 @@ runs:
     # --- Common: Maestro setup + run ---
     # Pinned to WalletConnect/actions master
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+      uses: WalletConnect/actions/maestro/pay-tests@dd7c71c7292ed568c0ce6c4160ad3c04863db3a0
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+      uses: WalletConnect/actions/maestro/setup@dd7c71c7292ed568c0ce6c4160ad3c04863db3a0
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'


### PR DESCRIPTION
## Summary

Bumps the WalletConnect/actions SHA pin in `walletkit-build-and-maestro/action.yml`:

```diff
-uses: WalletConnect/actions/maestro/pay-tests@3a145ab…
+uses: WalletConnect/actions/maestro/pay-tests@dd7c71c…
```

Picks up [WalletConnect/actions#98](https://github.com/WalletConnect/actions/pull/98):

| Flow | Step | Before | After |
|---|---|---|---|
| `pay_confirm_and_verify.yaml` | `pay-result-success-icon` | 30s | **60s** |
| `pay_open_and_paste_url.yaml` | `button-scan` | 60s | **90s** |

## Why now

Pay-core's `core (CD)` KPI for window 2026-06-05 → 2026-06-12: **pass rate 41.67% (5/12)**. Investigation showed 5 of 7 failures stuck on `pay-result-success-icon is visible` (wallet on \"Processing your payment…\" while staging gateway took 35–50s to flip `status=succeeded`), and 2 of 7 stuck on `button-scan` cold-start.

The pin here (`3a145ab`) is **one commit before #98**, so none of those 12 CD runs exercised the new budget — we have zero post-bump evidence and the KPI is a pre-bump baseline.

This PR is the missing link so pay-core's next pin-bump in `sub-validate-advisory.yml` actually picks up the new timeouts.

## Risk

Other Reown SDK Maestro suites that use this composite (the scheduled `ci_e2e_walletkit.yaml`, anywhere else?) inherit the same higher budgets. Both changes are upward only and `extendedWaitUntil` exits as soon as the element appears — green runs see no change, only previously-timing-out runs gain headroom.

## Test plan

- [ ] Wait for the scheduled `ci_e2e_walletkit.yaml` Maestro pay-tests run (every 6h per #532) and confirm it stays green at the new timeouts.
- [ ] Pay-core then bumps the rn-wallet ref in `sub-validate-advisory.yml` from `4e6dcea0` → tip of `main` here, and the next 10 CD runs are observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)