### PR TITLE
ci: cut Actions cost — split E2E schedule, run iOS once daily

### DIFF
--- a/.github/workflows/ci_e2e_tests_ios.yaml
+++ b/.github/workflows/ci_e2e_tests_ios.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   placeholder:
     name: Placeholder Job
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Do nothing
         run: echo "This is a placeholder workflow to enable manual triggers from feature branches."

--- a/.github/workflows/ci_e2e_walletkit.yaml
+++ b/.github/workflows/ci_e2e_walletkit.yaml
@@ -10,7 +10,8 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # Every 6 hours, UTC
+    - cron: '0 */6 * * *' # Every 6 hours, UTC — cheap canary (Android + balance check)
+    - cron: '0 9 * * *' # Once daily, UTC — also runs the expensive iOS E2E
   pull_request:
     branches: [main]
     paths:
@@ -53,7 +54,11 @@ jobs:
 
   e2e-ios:
     needs: check-balance
-    if: always() && inputs.platform != 'android' # Balance alert should not block tests
+    # Balance alert should not block tests. On schedule, iOS (macOS, expensive)
+    # runs only on the once-daily cron; the 6h cadence stays Android-only.
+    if: >-
+      always() && inputs.platform != 'android'
+      && (github.event_name != 'schedule' || github.event.schedule == '0 9 * * *')
     name: E2E Tests - iOS
     runs-on: macos-latest-xlarge
     timeout-minutes: 60


### PR DESCRIPTION
## Why

Last month's GitHub Actions bill was **~\$600**. An audit of the last 30 days showed it's ~95% macOS, concentrated in **one job**: the iOS half of `ci_e2e_walletkit.yaml`, on `macos-latest-xlarge` (\$0.16/min, 20× Linux).

| Runner | Jobs (30d) | Minutes | Est. cost |
|---|---|---|---|
| `macos-latest-xlarge` (E2E iOS) | 214 | 5,402 | ~\$864* |
| `ubuntu-latest` (android + balance) | 428 | 4,867 | ~\$39 |

\*list rate; the real bill nets free-tier/period boundaries — but macOS dominates either way. **514 of 619 E2E runs (83%) were the 6-hourly `schedule`**, each firing a ~\$4 macOS iOS build.

## What this keeps (the canary is preserved)

The scheduled run is a production canary with two Slack alert paths, and this PR keeps **both**:
- **E2E failure alert** → `SLACK_WEBHOOK_URL` when Maestro tests fail against prod (`api.pay.walletconnect.com`).
- **Faucet/balance alert** → `SLACK_FAUCETBOT_WEBHOOK_URL` when the test wallet's USDC on Base/Optimism runs low.

## Changes

1. **Split the schedule** in `ci_e2e_walletkit.yaml`:
   - `0 */6 * * *` (every 6h) now runs only the **cheap Linux jobs** — Android E2E + the balance/faucet check. Keeps both alerts at near-zero cost.
   - `0 9 * * *` (once daily) **additionally** runs the **expensive iOS** E2E. The `e2e-ios` job is gated to this cron on schedule events; PR / push / `workflow_dispatch` behaviour is unchanged.
2. **`ci_e2e_tests_ios.yaml`**: move the no-op placeholder job off `macos-latest` → `ubuntu-latest` (it only `echo`s).

## Expected impact

macOS iOS runs drop from ~120/mo (4×/day) to ~30/mo (1×/day) on the schedule — roughly **\$500+/mo saved** while retaining a daily iOS signal, a 6-hourly Android+balance canary, and full PR coverage.

Further optional levers (not in this PR): `macos-latest-xlarge` → `macos-latest` (~50% off remaining macOS) and lowering the iOS `timeout-minutes` 60 → 40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)