### PR TITLE
ci(walletkit-maestro): re-pin WalletConnect/actions d07c1f8a → 3fd66ca

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -408,13 +408,14 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     # --- Common: Maestro setup + run ---
-    # TEMP: pinned to the WalletConnect/actions PR #97 head (adds pay_usdt_polygon).
-    # Re-pin to the squash-merge commit on master once #97 lands.
+    # Pinned to WalletConnect/actions master tip (3fd66ca = squash-merge of #97).
+    # Includes #96's launchApp retry-on-attach-failure block in pay_open_and_paste_url.yaml
+    # plus #97's USDT-on-Polygon flow + permit2-reset action.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b
+      uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@dd7c71c7292ed568c0ce6c4160ad3c04863db3a0
+      uses: WalletConnect/actions/maestro/setup@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'
@@ -580,7 +581,7 @@ runs:
     - name: Reset USDT Permit2 allowance (Polygon)
       if: always() && contains(inputs.maestro-tags, 'pay')
       continue-on-error: true
-      uses: WalletConnect/actions/maestro/permit2-reset@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b
+      uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}


### PR DESCRIPTION
## Summary

[#533](https://github.com/reown-com/react-native-examples/pull/533) pinned three \`uses:\` of \`WalletConnect/actions\` to \`d07c1f8a\` — that's the head of [WalletConnect/actions#97](https://github.com/WalletConnect/actions/pull/97)'s **pre-squash branch**. The PR was squash-merged to master as \`3fd66ca\`, which is the durable reference (the branch SHA is only reachable through PR history, not master).

```diff
-uses: WalletConnect/actions/maestro/pay-tests@d07c1f8a…    # pre-squash branch
+uses: WalletConnect/actions/maestro/pay-tests@3fd66ca…    # master squash-merge

-uses: WalletConnect/actions/maestro/setup@dd7c71c…         # diverged (older)
+uses: WalletConnect/actions/maestro/setup@3fd66ca…         # aligned

-uses: WalletConnect/actions/maestro/permit2-reset@d07c1f8a…
+uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca…
```

## Why this matters beyond hygiene

\`d07c1f8a\`'s tree **predates** the launchApp retry-on-attach-failure block in \`pay_open_and_paste_url.yaml\` that landed as [WalletConnect/actions#96](https://github.com/WalletConnect/actions/pull/96) (squash-merge \`0730e32\`):

```yaml
- retry:
    maxRetries: 3
    commands:
      - stopApp: { appId: \${APP_ID} }
      - launchApp: { appId: \${APP_ID}, permissions: { all: allow } }
      - extendedWaitUntil:
          visible: { id: \"button-scan\" }
          timeout: 90000
```

#96 is an ancestor of \`3fd66ca\` on master but **not** an ancestor of \`d07c1f8a\` (the squash-merge ordering reverses the date order). So every consumer of this composite is currently running without #96's retry, and the Android \`ActivityManager: Process … failed to attach\` failure mode is back on contended emulators.

Evidence from pay-core CD run [27534171160](https://github.com/WalletConnect/pay-core/actions/runs/27534171160) (2026-06-15):
- 5× \`ActivityManager: Process ProcessRecord{…} failed to attach\` in \`android-logcat.log\` for \`com.walletconnect.web3wallet.rnsample.internal\`
- 4 different flows timed out on \`button-scan is visible\` at exactly the 90s budget (= app was killed, never re-launched)
- All 4 failures on attempt 2 of pay-core's outer retry — same cluster

## What \`3fd66ca\` brings in

| Change | Source |
|---|---|
| launchApp retry-on-attach-failure block | #96 \`0730e32\` |
| USDT-on-Polygon flow + permit2-reset action | #97 \`3fd66ca\` |
| End-to-end success + button-scan timeout bumps (already in #533) | #98 \`dd7c71c\` |

No flow logic regressions — #96 is purely additive (wraps existing commands in \`retry:\`), #97 only adds new files.

## Test plan

- [ ] Wait for the next scheduled \`ci_e2e_walletkit.yaml\` Maestro run (every 6h per #532) — confirm green with the retry path active.
- [ ] Then pay-core bumps its rn-wallet ref to this merge commit and adds \`maestro-exclude-tags: pay-usdt-polygon\` (staging multi-option no-KYC merchant doesn't offer USDT-Polygon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)