### PR TITLE
ci(walletkit-maestro): speed up E2E builds via single-arch iOS + caching

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -244,21 +244,10 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.paths.outputs.wallet_root }}/ios/Pods
+        # No restore-keys: a prefix match restores a stale Pods/ on a Podfile.lock
+        # bump (hermes-engine podspec mismatch) and breaks `pod install`. Exact
+        # match only — also gates the Fastfile's pod-install skip (#515).
         key: ${{ runner.os }}-pods-${{ github.ref_name }}-${{ hashFiles(format('{0}/ios/Podfile.lock', steps.paths.outputs.wallet_root)) }}
-        restore-keys: |
-          ${{ runner.os }}-pods-${{ github.ref_name }}-
-
-    # Cache xcodebuild's compiled objects (Pods, Hermes, RN core) for incremental builds.
-    # The Pods cache above only covers source. Path matches the Fastfile's derived_data_path.
-    - name: Cache DerivedData
-      if: inputs.platform == 'ios'
-      uses: actions/cache@v4
-      with:
-        path: ${{ inputs.wallet-source-dir }}/build/DerivedData
-        key: ${{ runner.os }}-dd-${{ github.ref_name }}-${{ hashFiles(format('{0}/ios/Podfile.lock', steps.paths.outputs.wallet_root), format('{0}/yarn.lock', steps.paths.outputs.wallet_root)) }}
-        restore-keys: |
-          ${{ runner.os }}-dd-${{ github.ref_name }}-
-          ${{ runner.os }}-dd-
 
     - name: Build for Simulator
       if: inputs.platform == 'ios'

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -245,8 +245,8 @@ runs:
       with:
         path: ${{ steps.paths.outputs.wallet_root }}/ios/Pods
         # No restore-keys: a prefix match restores a stale Pods/ on a Podfile.lock
-        # bump (hermes-engine podspec mismatch) and breaks `pod install`. Exact
-        # match only — also gates the Fastfile's pod-install skip (#515).
+        # bump (hermes-engine podspec mismatch) and breaks `pod install` (#515).
+        # Exact Podfile.lock match only; otherwise start clean and reinstall.
         key: ${{ runner.os }}-pods-${{ github.ref_name }}-${{ hashFiles(format('{0}/ios/Podfile.lock', steps.paths.outputs.wallet_root)) }}
 
     - name: Build for Simulator

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -248,6 +248,18 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pods-${{ github.ref_name }}-
 
+    # Cache xcodebuild's compiled objects (Pods, Hermes, RN core) for incremental builds.
+    # The Pods cache above only covers source. Path matches the Fastfile's derived_data_path.
+    - name: Cache DerivedData
+      if: inputs.platform == 'ios'
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.wallet-source-dir }}/build/DerivedData
+        key: ${{ runner.os }}-dd-${{ github.ref_name }}-${{ hashFiles(format('{0}/ios/Podfile.lock', steps.paths.outputs.wallet_root), format('{0}/yarn.lock', steps.paths.outputs.wallet_root)) }}
+        restore-keys: |
+          ${{ runner.os }}-dd-${{ github.ref_name }}-
+          ${{ runner.os }}-dd-
+
     - name: Build for Simulator
       if: inputs.platform == 'ios'
       uses: maierj/fastlane-action@v3.0.0
@@ -378,6 +390,8 @@ runs:
           ~/.gradle/caches
           ~/.gradle/wrapper
           ${{ steps.paths.outputs.wallet_root }}/android/.gradle
+          ${{ steps.paths.outputs.wallet_root }}/android/app/.cxx
+          ${{ steps.paths.outputs.wallet_root }}/android/app/build/generated
         key: ${{ runner.os }}-gradle-walletkit-${{ hashFiles(format('{0}/android/**/*.gradle*', steps.paths.outputs.wallet_root), format('{0}/android/**/gradle-wrapper.properties', steps.paths.outputs.wallet_root)) }}
         restore-keys: |
           ${{ runner.os }}-gradle-walletkit-

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,6 +150,10 @@ platform :ios do
     build_dir   = File.expand_path("../build")
     archive_path = "#{build_dir}/wallet-simulator.xcarchive"
 
+    # Build only arm64 (the runner is Apple Silicon) instead of both sim slices, and skip
+    # the compiler index store CI never reads. Base string so the signing branch can append.
+    xcargs = "ARCHS=arm64 ONLY_ACTIVE_ARCH=YES COMPILER_INDEX_STORE_ENABLE=NO"
+
     gym_params = {
       workspace: ENV['XCWORKSPACE_PATH'],
       scheme: ENV['SCHEME'],
@@ -157,11 +161,14 @@ platform :ios do
       destination: "generic/platform=iOS Simulator",
       archive_path: archive_path,
       skip_package_ipa: true,
+      # Stable path so CI can cache compiled objects across runs (see Cache DerivedData step).
+      derived_data_path: "#{build_dir}/DerivedData",
     }
 
     if sign_build
-      gym_params[:xcargs] = "CODE_SIGNING_ALLOWED=YES"
+      gym_params[:xcargs] = "#{xcargs} CODE_SIGNING_ALLOWED=YES"
     else
+      gym_params[:xcargs] = xcargs
       gym_params[:skip_codesigning] = true
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,12 +138,17 @@ platform :ios do
       )
     end
 
-    # Install pods (skip repo_update if cache hit)
-    cocoapods(
-      clean_install: false,
-      repo_update: ENV['PODS_CACHE_HIT'] != 'true',
-      podfile: ENV['PODFILE_PATH']
-    )
+    # On an exact Pods cache hit the restored Pods/ matches Podfile.lock, so
+    # re-running pod install (~5 min) is redundant. Reinstall only on a miss.
+    if ENV['PODS_CACHE_HIT'] == 'true'
+      UI.message("✅ Pods cache hit — skipping pod install (Pods/ matches Podfile.lock)")
+    else
+      cocoapods(
+        clean_install: false,
+        repo_update: true,
+        podfile: ENV['PODFILE_PATH']
+      )
+    end
 
     # Use an absolute path — gym (xcodebuild) runs from repo root while Ruby Dir/File
     # operations use the fastlane/ directory as CWD, so relative paths diverge.
@@ -161,7 +166,6 @@ platform :ios do
       destination: "generic/platform=iOS Simulator",
       archive_path: archive_path,
       skip_package_ipa: true,
-      derived_data_path: "#{build_dir}/DerivedData",
     }
 
     if sign_build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -161,7 +161,6 @@ platform :ios do
       destination: "generic/platform=iOS Simulator",
       archive_path: archive_path,
       skip_package_ipa: true,
-      # Stable path so CI can cache compiled objects across runs (see Cache DerivedData step).
       derived_data_path: "#{build_dir}/DerivedData",
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,17 +138,15 @@ platform :ios do
       )
     end
 
-    # On an exact Pods cache hit the restored Pods/ matches Podfile.lock, so
-    # re-running pod install (~5 min) is redundant. Reinstall only on a miss.
-    if ENV['PODS_CACHE_HIT'] == 'true'
-      UI.message("✅ Pods cache hit — skipping pod install (Pods/ matches Podfile.lock)")
-    else
-      cocoapods(
-        clean_install: false,
-        repo_update: true,
-        podfile: ENV['PODFILE_PATH']
-      )
-    end
+    # Always run pod install: on New Arch it also runs RN codegen, writing
+    # ios/build/generated/**-generated.mm that the ReactCodegen Pods target
+    # compiles. That output isn't cached or committed, so it can't be skipped.
+    # Skip only repo_update on an exact cache hit (Podfile.lock unchanged).
+    cocoapods(
+      clean_install: false,
+      repo_update: ENV['PODS_CACHE_HIT'] != 'true',
+      podfile: ENV['PODFILE_PATH']
+    )
 
     # Use an absolute path — gym (xcodebuild) runs from repo root while Ruby Dir/File
     # operations use the fastlane/ directory as CWD, so relative paths diverge.


### PR DESCRIPTION
## What & why

The Maestro E2E build dominates each run's wall-clock time. This trims it on both PR and scheduled runs via the shared composite action — no extra CI cost, no change to test behavior.

## Changes

- **iOS — single-arch build** (`fastlane/Fastfile`): `gym` now builds only `arm64` (the `macos-latest-xlarge` runner is Apple Silicon) instead of both arm64 + x86_64 simulator slices, and skips the compiler index store CI never reads. This is the main win — the archive compile drops from ~6m45s to ~4m.
- **iOS — drop pods cache `restore-keys`** (`action.yml`): a prefix match could restore a stale `Pods/` on a `Podfile.lock` bump (hermes-engine podspec mismatch) and break `pod install`. Exact-match only now. Ports the #515 fix to this action.
- **Android — cache native build outputs** (`action.yml`): added `android/app/.cxx` and `android/app/build/generated` to the Gradle cache so the New-Arch NDK/CMake compile is incremental.

## Measured results (single Maestro attempt, no retry — apples-to-apples)

| Job | Before | After | Δ |
| --- | --- | --- | --- |
| iOS | ~26m | ~23m | ~3.5 min faster |
| Android | ~29m | ~25m | ~4.5 min faster |

## Notes

Two approaches were tried and reverted: caching iOS DerivedData gave ~nothing (RN core/Hermes ship as prebuilt XCFrameworks, so there's little to recompile), and skipping `pod install` on a cache hit broke the build because New-Arch RN codegen runs *during* `pod install` and writes uncached `ios/build/generated/*-generated.mm`. `pod install` (~5 min) and Maestro test time remain the largest costs and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)