### PR TITLE
ci(walletkit-maestro): per-flow native recording, kept on failure

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -450,6 +450,14 @@ runs:
         WPAY_PAY_API_URL: ${{ inputs.pay-api-url }}
         WPAY_EXPIRED_GATEWAY_URL: ${{ inputs.expired-gateway-url }}
       run: |
+        # Pre-grant simulator privacy permissions. Maestro does this via the
+        # flows' `launchApp: permissions: all: allow`, but Ennio doesn't enforce
+        # it AND can't dismiss the system alert (it only sees the injected RN
+        # app's view tree, not the SpringBoard camera prompt). Without this, the
+        # scan screen's VisionCamera prompt freezes every flow on a clean sim.
+        # Harmless/redundant for the Maestro path.
+        xcrun simctl privacy "$DEVICE_ID" grant all "$APP_ID" 2>/dev/null || true
+        xcrun simctl privacy "$DEVICE_ID" grant camera "$APP_ID" 2>/dev/null || true
         xcrun simctl launch "$DEVICE_ID" "$APP_ID" || true
         mkdir -p maestro-artifacts
         # Snapshot the associated-domains verification state at run start — brackets the

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -408,11 +408,13 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions master tip (3fd66ca = squash-merge of #97).
-    # Includes #96's launchApp retry-on-attach-failure block in pay_open_and_paste_url.yaml
-    # plus #97's USDT-on-Polygon flow + permit2-reset action.
+    # Pinned to WalletConnect/actions#99 (tool-agnostic flows: startRecording/
+    # stopRecording removed, copiedText assertTrue -> assertVisible; also ships
+    # scripts/run-pay-flows.sh, the per-flow recording runner used below).
+    # Builds on 3fd66ca (#96 launchApp retry block + #97 USDT-on-Polygon flow).
+    # TODO: re-pin to the squash-merge commit once #99 lands.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
+      uses: WalletConnect/actions/maestro/pay-tests@98cccbcc6d872e1e18eb7aa0723dce969bbaa938
 
     - name: Install Maestro
       uses: WalletConnect/actions/maestro/setup@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
@@ -447,38 +449,17 @@ runs:
           > maestro-artifacts/ios-syslog.log 2>&1 &
         SYSLOG_PID=$!
         set +e
-        # Retry the suite once on failure to absorb transient cold-start flakes
-        # (e.g. an app process that fails to launch/attach) without rebuilding the
-        # app or rebooting the simulator. A genuine failure fails every attempt, so
-        # this does not mask regressions. The syslog stream above keeps capturing
-        # across both attempts.
-        maestro_exit_code=0
-        # Clear any stale per-attempt logs (composite may be invoked twice per job).
-        rm -f maestro-output-attempt-*.log
-        for attempt in 1 2; do
-          echo "=== Maestro attempt $attempt/2 (iOS) ==="
-          $HOME/.maestro/bin/maestro test \
-            --env APP_ID="$APP_ID" \
-            --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC="$WPAY_CUSTOMER_KEY_SINGLE_NOKYC" \
-            --env WPAY_MERCHANT_ID_SINGLE_NOKYC="$WPAY_MERCHANT_ID_SINGLE_NOKYC" \
-            --env WPAY_CUSTOMER_KEY_MULTI_NOKYC="$WPAY_CUSTOMER_KEY_MULTI_NOKYC" \
-            --env WPAY_MERCHANT_ID_MULTI_NOKYC="$WPAY_MERCHANT_ID_MULTI_NOKYC" \
-            --env WPAY_CUSTOMER_KEY_MULTI_KYC="$WPAY_CUSTOMER_KEY_MULTI_KYC" \
-            --env WPAY_MERCHANT_ID_MULTI_KYC="$WPAY_MERCHANT_ID_MULTI_KYC" \
-            --env WPAY_PAY_API_URL="$WPAY_PAY_API_URL" \
-            --env WPAY_EXPIRED_GATEWAY_URL="$WPAY_EXPIRED_GATEWAY_URL" \
-            --include-tags "$MAESTRO_TAGS" \
-            ${MAESTRO_EXCLUDE_TAGS:+--exclude-tags "$MAESTRO_EXCLUDE_TAGS"} \
-            --test-output-dir maestro-artifacts \
-            --debug-output "${RUNNER_TEMP}/maestro-debug" \
-            .maestro/ >"maestro-output-attempt-${attempt}.log" 2>&1
-          maestro_exit_code=$?
-          [ "$maestro_exit_code" -eq 0 ] && break
-          echo "Maestro attempt $attempt failed (exit $maestro_exit_code)"
-        done
-        # Join per-attempt logs so the uploaded artifact keeps attempt 1's output
-        # on a double failure (otherwise attempt 2 would have overwritten it).
-        for f in maestro-output-attempt-*.log; do echo "=== $f ==="; cat "$f"; done > maestro-output.log
+        # Run each flow in its own invocation, wrapped in a native screen recording
+        # that is kept only when the flow fails (one video per flow, not one giant
+        # suite video). Per-flow retry (ATTEMPTS=2) still absorbs transient
+        # cold-start flakes without rebuilding/rebooting. The shared runner is
+        # copied into .maestro/scripts by the pay-tests action above.
+        PLATFORM=ios DEVICE_ID="$DEVICE_ID" RUNNER=maestro ATTEMPTS=2 \
+          FLOWS_DIR=.maestro OUT_DIR=maestro-artifacts \
+          INCLUDE_TAGS="$MAESTRO_TAGS" EXCLUDE_TAGS="$MAESTRO_EXCLUDE_TAGS" \
+          DEBUG_OUTPUT="${RUNNER_TEMP}/maestro-debug" \
+          bash .maestro/scripts/run-pay-flows.sh > maestro-output.log 2>&1
+        maestro_exit_code=$?
         kill "$SYSLOG_PID" 2>/dev/null || true
         wait "$SYSLOG_PID" 2>/dev/null || true
         mkdir -p maestro-artifacts/ios-crash-reports
@@ -545,7 +526,26 @@ runs:
         disable-animations: true
         script: |
           adb install "$APK_PATH"
-          mkdir -p maestro-artifacts maestro-artifacts/maestro-debug; adb logcat -c || true; adb logcat AndroidRuntime:E ActivityManager:W ReactNativeJS:E '*:F' > maestro-artifacts/android-logcat.log 2>&1 & LOGCAT_PID=$!; set +e; maestro_exit_code=0; rm -f maestro-output-attempt-*.log; for attempt in 1 2; do echo "=== Maestro attempt $attempt/2 (Android) ==="; $HOME/.maestro/bin/maestro test --env APP_ID="$APP_ID" --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC="$WPAY_CUSTOMER_KEY_SINGLE_NOKYC" --env WPAY_MERCHANT_ID_SINGLE_NOKYC="$WPAY_MERCHANT_ID_SINGLE_NOKYC" --env WPAY_CUSTOMER_KEY_MULTI_NOKYC="$WPAY_CUSTOMER_KEY_MULTI_NOKYC" --env WPAY_MERCHANT_ID_MULTI_NOKYC="$WPAY_MERCHANT_ID_MULTI_NOKYC" --env WPAY_CUSTOMER_KEY_MULTI_KYC="$WPAY_CUSTOMER_KEY_MULTI_KYC" --env WPAY_MERCHANT_ID_MULTI_KYC="$WPAY_MERCHANT_ID_MULTI_KYC" --env WPAY_PAY_API_URL="$WPAY_PAY_API_URL" --env WPAY_EXPIRED_GATEWAY_URL="$WPAY_EXPIRED_GATEWAY_URL" --include-tags "$MAESTRO_TAGS" ${MAESTRO_EXCLUDE_TAGS:+--exclude-tags "$MAESTRO_EXCLUDE_TAGS"} --test-output-dir maestro-artifacts --debug-output "${RUNNER_TEMP}/maestro-debug" .maestro/ >"maestro-output-attempt-${attempt}.log" 2>&1; maestro_exit_code=$?; [ "$maestro_exit_code" -eq 0 ] && break; echo "Maestro attempt $attempt failed (exit $maestro_exit_code)"; done; for f in maestro-output-attempt-*.log; do echo "=== $f ==="; cat "$f"; done > maestro-output.log; kill "$LOGCAT_PID" 2>/dev/null || true; wait "$LOGCAT_PID" 2>/dev/null || true; adb logcat -d -b crash > maestro-artifacts/android-logcat-crash.log 2>&1 || true; find "${RUNNER_TEMP}/maestro-debug" -type f \( -name '*.png' -o -name '*.jpg' \) -exec cp {} maestro-artifacts/maestro-debug/ \; 2>/dev/null || true; cat maestro-output.log; exit "$maestro_exit_code"
+          mkdir -p maestro-artifacts maestro-artifacts/maestro-debug
+          adb logcat -c || true
+          adb logcat AndroidRuntime:E ActivityManager:W ReactNativeJS:E '*:F' > maestro-artifacts/android-logcat.log 2>&1 &
+          LOGCAT_PID=$!
+          set +e
+          # Per-flow run with native screen recording (adb screenrecord), kept
+          # only on failure. Shared runner copied into .maestro/scripts by the
+          # pay-tests action. screenrecord's 180s cap is safe per single flow.
+          PLATFORM=android RUNNER=maestro ATTEMPTS=2 \
+            FLOWS_DIR=.maestro OUT_DIR=maestro-artifacts \
+            INCLUDE_TAGS="$MAESTRO_TAGS" EXCLUDE_TAGS="$MAESTRO_EXCLUDE_TAGS" \
+            DEBUG_OUTPUT="${RUNNER_TEMP}/maestro-debug" \
+            bash .maestro/scripts/run-pay-flows.sh > maestro-output.log 2>&1
+          maestro_exit_code=$?
+          kill "$LOGCAT_PID" 2>/dev/null || true
+          wait "$LOGCAT_PID" 2>/dev/null || true
+          adb logcat -d -b crash > maestro-artifacts/android-logcat-crash.log 2>&1 || true
+          find "${RUNNER_TEMP}/maestro-debug" -type f \( -name '*.png' -o -name '*.jpg' \) -exec cp {} maestro-artifacts/maestro-debug/ \; 2>/dev/null || true
+          cat maestro-output.log
+          exit "$maestro_exit_code"
 
     - name: Upload Maestro artifacts (Android)
       if: always() && inputs.platform == 'android'

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -422,6 +422,17 @@ runs:
     - name: Install Maestro
       uses: WalletConnect/actions/maestro/setup@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
 
+    # EXPERIMENT: run the iOS suite under Ennio (RN-only fast runner) to measure
+    # CI wall-clock vs Maestro. Ships a prebuilt arm64 dylib (matches the
+    # macos arm64 runner); injects at app launch on the simulator. `ennio doctor`
+    # is best-effort visibility into the runner's Node/Xcode/dylib/sim state.
+    - name: Install Ennio (iOS experiment)
+      if: inputs.platform == 'ios'
+      shell: bash
+      run: |
+        npm install -g @reactiive/ennio
+        ennio doctor || true
+
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'
       id: maestro-ios
@@ -457,7 +468,12 @@ runs:
         # suite video). Per-flow retry (ATTEMPTS=2) still absorbs transient
         # cold-start flakes without rebuilding/rebooting. The shared runner is
         # copied into .maestro/scripts by the pay-tests action above.
-        PLATFORM=ios DEVICE_ID="$DEVICE_ID" RUNNER=maestro ATTEMPTS=2 \
+        # EXPERIMENT: RUNNER=ennio. Ennio has no tag filtering, so it runs the
+        # full .maestro/pay_*.yaml glob (all pay flows, incl. the deeplink/
+        # universal-link ones — the app is signed on CI so AASA routing works).
+        # MAESTRO_TAGS is ignored by the ennio path. ENNIO_UDID pins it to the
+        # E2E simulator. Switch back to RUNNER=maestro to restore the gate.
+        PLATFORM=ios DEVICE_ID="$DEVICE_ID" ENNIO_UDID="$DEVICE_ID" RUNNER=ennio ATTEMPTS=2 \
           FLOWS_DIR=.maestro OUT_DIR=maestro-artifacts \
           INCLUDE_TAGS="$MAESTRO_TAGS" EXCLUDE_TAGS="$MAESTRO_EXCLUDE_TAGS" \
           DEBUG_OUTPUT="${RUNNER_TEMP}/maestro-debug" \
@@ -527,28 +543,15 @@ runs:
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-load
         disable-animations: true
+        # NOTE: android-emulator-runner executes each LINE of `script` as its own
+        # `sh -c`, so the per-flow run must be a single line — multi-line + `\`
+        # continuations break (the `\` runs as its own command → exit 127) and
+        # shell variables wouldn't persist across lines. Native recording (adb
+        # screenrecord, kept on failure) lives in the shared run-pay-flows.sh,
+        # copied into .maestro/scripts by the pay-tests action.
         script: |
           adb install "$APK_PATH"
-          mkdir -p maestro-artifacts maestro-artifacts/maestro-debug
-          adb logcat -c || true
-          adb logcat AndroidRuntime:E ActivityManager:W ReactNativeJS:E '*:F' > maestro-artifacts/android-logcat.log 2>&1 &
-          LOGCAT_PID=$!
-          set +e
-          # Per-flow run with native screen recording (adb screenrecord), kept
-          # only on failure. Shared runner copied into .maestro/scripts by the
-          # pay-tests action. screenrecord's 180s cap is safe per single flow.
-          PLATFORM=android RUNNER=maestro ATTEMPTS=2 \
-            FLOWS_DIR=.maestro OUT_DIR=maestro-artifacts \
-            INCLUDE_TAGS="$MAESTRO_TAGS" EXCLUDE_TAGS="$MAESTRO_EXCLUDE_TAGS" \
-            DEBUG_OUTPUT="${RUNNER_TEMP}/maestro-debug" \
-            bash .maestro/scripts/run-pay-flows.sh > maestro-output.log 2>&1
-          maestro_exit_code=$?
-          kill "$LOGCAT_PID" 2>/dev/null || true
-          wait "$LOGCAT_PID" 2>/dev/null || true
-          adb logcat -d -b crash > maestro-artifacts/android-logcat-crash.log 2>&1 || true
-          find "${RUNNER_TEMP}/maestro-debug" -type f \( -name '*.png' -o -name '*.jpg' \) -exec cp {} maestro-artifacts/maestro-debug/ \; 2>/dev/null || true
-          cat maestro-output.log
-          exit "$maestro_exit_code"
+          mkdir -p maestro-artifacts maestro-artifacts/maestro-debug; adb logcat -c || true; adb logcat AndroidRuntime:E ActivityManager:W ReactNativeJS:E '*:F' > maestro-artifacts/android-logcat.log 2>&1 & LOGCAT_PID=$!; set +e; PLATFORM=android RUNNER=maestro ATTEMPTS=2 FLOWS_DIR=.maestro OUT_DIR=maestro-artifacts INCLUDE_TAGS="$MAESTRO_TAGS" EXCLUDE_TAGS="$MAESTRO_EXCLUDE_TAGS" DEBUG_OUTPUT="${RUNNER_TEMP}/maestro-debug" bash .maestro/scripts/run-pay-flows.sh > maestro-output.log 2>&1; maestro_exit_code=$?; kill "$LOGCAT_PID" 2>/dev/null || true; wait "$LOGCAT_PID" 2>/dev/null || true; adb logcat -d -b crash > maestro-artifacts/android-logcat-crash.log 2>&1 || true; find "${RUNNER_TEMP}/maestro-debug" -type f \( -name '*.png' -o -name '*.jpg' \) -exec cp {} maestro-artifacts/maestro-debug/ \; 2>/dev/null || true; cat maestro-output.log; exit "$maestro_exit_code"
 
     - name: Upload Maestro artifacts (Android)
       if: always() && inputs.platform == 'android'


### PR DESCRIPTION
## What
Switches the WalletKit Maestro run (iOS + Android) from one suite invocation (`maestro test .maestro/`) to a **per-flow loop** that wraps each flow in a native screen recording (`simctl io recordVideo` / `adb screenrecord`) and **keeps the video only when that flow fails** — one video per flow instead of one giant suite video.

The recording/retry logic lives in the shared `run-pay-flows.sh` runner (copied into `.maestro/scripts` by the pay-tests action) so it isn't duplicated here.

## Why
We're making the shared Pay flows **tool-agnostic** (WalletConnect/actions#99) by removing `startRecording`/`stopRecording` so the same flows also run on [Ennio](https://github.com/enzomanuelmangano/ennio) for fast local RN iteration. Those in-flow commands were what produced per-flow videos, so this PR gives them back at the runner level — for **both** runners, and capturing the full screen (incl. native↔web transitions).

## Changes
- `walletkit-build-and-maestro/action.yml`: iOS + Android run steps call `run-pay-flows.sh` (per-flow record + 2× retry + keep-on-fail). Syslog streaming, crash-report collection, debug screenshots, and artifact upload (already globs `*.mp4`) unchanged.
- Bump `pay-tests` pinned ref to WalletConnect/actions#99 head (`98cccbc`). **Re-pin to the squash-merge commit before merge.**

## Behavior changes to note
- **Retry is now per-flow** (was whole-suite). A flaky flow reruns alone instead of rerunning the entire suite — cheaper and more isolated.
- **Tag filtering is glob-based** (`.maestro/pay_*.yaml`) plus `--include-tags` per file. Matches today's effective set (only pay-tagged flows ran); revisit if non-`pay` tag runs are needed.
- Android `adb screenrecord` has a ~180s/file cap — safe per single pay flow, would not be for a whole-suite recording.

## Validation
Locally (rn_cli_wallet RN 0.85.3, iPhone 16 sim) the runner + flows pass on Maestro and Ennio across single/multiple-option (no-KYC), cancelled, insufficient-funds, expired-link, with keep-on-failure confirmed. **Not yet validated in CI** — opening as draft to run the workflow and confirm the iOS/Android steps + artifact upload behave end-to-end.

## Depends on
- WalletConnect/actions#99 (tool-agnostic flows + `run-pay-flows.sh`). Merge/finalize that first, then re-pin the ref here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)