### PR TITLE
fix(walletkit-maestro): pre-install NDK + make Permit2 reset non-fatal

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -340,8 +340,12 @@ runs:
     - name: Install Android NDK 27.0.12077973
       if: inputs.platform == 'android'
       shell: bash
+      # Licenses are accepted by the previous step, so `sdkmanager` reads little
+      # stdin and `yes` takes SIGPIPE when it exits. Disable pipefail (the default
+      # shell runs with -e -o pipefail) so that broken pipe doesn't fail the step —
+      # `sdkmanager`'s own exit code (last in the pipe) is what governs.
       run: |
-        set -euo pipefail
+        set +o pipefail
         yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "ndk;27.0.12077973"
 
     - name: Add Secrets file

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -601,7 +601,7 @@ runs:
     # (actions/runner#1457), so non-fatal behavior is enforced via fail-on-error.
     - name: Reset USDT Permit2 allowance (Polygon)
       if: always() && contains(inputs.maestro-tags, 'pay')
-      uses: WalletConnect/actions/maestro/permit2-reset@0bad13563193ae9b18e4659b248db62f17c66b1d
+      uses: WalletConnect/actions/maestro/permit2-reset@8a83c203760286acef29408833dbd0d075932932
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -332,6 +332,18 @@ runs:
       if: inputs.platform == 'android'
       uses: SimonMarquis/android-accept-licenses@8d8deab5b7ab2aaea9ed69f0b802e53173f21fd1 # v1
 
+    # Gradle/AGP auto-installs the build.gradle-requested NDK at build time, and
+    # that download fails on the CI runner (InstallFailedException: ndk;27.0.12077973).
+    # Pre-install it explicitly via the cmdline-tools sdkmanager (licenses accepted
+    # above) so the build finds it instead of trying — and failing — to fetch it.
+    # Keep the version in lockstep with the wallet's build.gradle ndkVersion.
+    - name: Install Android NDK 27.0.12077973
+      if: inputs.platform == 'android'
+      shell: bash
+      run: |
+        set -euo pipefail
+        yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "ndk;27.0.12077973"
+
     - name: Add Secrets file
       if: inputs.platform == 'android'
       shell: bash
@@ -580,16 +592,18 @@ runs:
     # re-exercises the approve step. Runs even when the suite failed (if: always())
     # so a mid-flow failure doesn't leave the allowance set. Uses the shared
     # permit2-reset action (the private key goes via env, never the CLI).
-    # continue-on-error so a reset hiccup can't fail an otherwise-green run.
+    # Best-effort: a reset hiccup must not fail an otherwise-green run. NOTE that
+    # `continue-on-error` is ignored on a step that `uses:` a composite action
+    # (actions/runner#1457), so non-fatal behavior is enforced via fail-on-error.
     - name: Reset USDT Permit2 allowance (Polygon)
       if: always() && contains(inputs.maestro-tags, 'pay')
-      continue-on-error: true
-      uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
+      uses: WalletConnect/actions/maestro/permit2-reset@0bad13563193ae9b18e4659b248db62f17c66b1d
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}
         token-address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
         private-key: ${{ inputs.wallet-private-key }}
+        fail-on-error: 'false'
 
     - name: Log Maestro outcome
       if: always()


### PR DESCRIPTION
## Problem

The Android `walletkit-build-and-maestro` E2E job has two independent failure modes (both observed in pay-core CD's `WX Pay E2E Maestro - android - staging`):

1. **Build dies installing the NDK.** Gradle/AGP auto-installs the `build.gradle`-requested NDK at build time, and that download fails on the CI runner:
   ```
   com.android.builder.sdk.InstallFailedException: Failed to install the following SDK components:
         ndk;27.0.12077973 NDK (Side by side) 27.0.12077973
   ```
   Both retry attempts die here, before any Maestro flow runs.

2. **Permit2 reset can fail the whole job.** The post-test allowance reset is best-effort, and the step sets `continue-on-error: true` — but the runner **ignores `continue-on-error` on steps inside composite actions** ([actions/runner#1457](https://github.com/actions/runner/issues/1457)). So a revoke failure (e.g. the reset wallet running out of gas) reddens the job.

## Changes

1. Add an explicit **`Install Android NDK 27.0.12077973`** step (sdkmanager, after license acceptance) so the build finds the NDK instead of trying — and failing — to fetch it mid-build. The later "Free disk space" step removes the NDK only *after* the build, so there's no conflict.

2. Switch the reset step to the new **`fail-on-error: 'false'`** input on `permit2-reset` (depends on WalletConnect/actions#101) and bump the pin. Removed the now-redundant `continue-on-error` and documented why.

## Depends on

- WalletConnect/actions#101 (adds `fail-on-error`). The pin here points at that PR's head SHA (`0bad135`); **bump to the squash-merge SHA once #101 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)