### PR TITLE
ci(walletkit-maestro): don't fail job on transient artifact upload errors

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -509,8 +509,6 @@ runs:
 
     - name: Upload Maestro artifacts (iOS)
       if: always() && inputs.platform == 'ios'
-      # Diagnostic-only artifacts: a transient upload failure (e.g. ENOTFOUND
-      # reaching GitHub's artifact backend) shouldn't fail the job after tests pass.
       continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
@@ -571,8 +569,6 @@ runs:
 
     - name: Upload Maestro artifacts (Android)
       if: always() && inputs.platform == 'android'
-      # Diagnostic-only artifacts: a transient upload failure (e.g. ENOTFOUND
-      # reaching GitHub's artifact backend) shouldn't fail the job after tests pass.
       continue-on-error: true
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -509,6 +509,9 @@ runs:
 
     - name: Upload Maestro artifacts (iOS)
       if: always() && inputs.platform == 'ios'
+      # Diagnostic-only artifacts: a transient upload failure (e.g. ENOTFOUND
+      # reaching GitHub's artifact backend) shouldn't fail the job after tests pass.
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: maestro-ios-artifacts
@@ -568,6 +571,9 @@ runs:
 
     - name: Upload Maestro artifacts (Android)
       if: always() && inputs.platform == 'android'
+      # Diagnostic-only artifacts: a transient upload failure (e.g. ENOTFOUND
+      # reaching GitHub's artifact backend) shouldn't fail the job after tests pass.
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: maestro-android-artifacts


### PR DESCRIPTION
## What

Adds `continue-on-error: true` to both Maestro artifact upload steps (iOS and Android) in `.github/actions/walletkit-build-and-maestro/action.yml`.

## Why

A recent CI run had **all Maestro tests pass**, but the job still went red because the post-test artifact upload failed at the network layer:

```
Error: Failed to CreateArtifact: Unable to make request: ENOTFOUND
```

This is a transient DNS/network error on the runner reaching GitHub's artifact backend — not a code or test failure.

These artifacts (screenshots, recordings, logs) are diagnostic-only and shouldn't gate the job. With this change, a flaky upload is still surfaced as a failed step but no longer fails the whole job after tests have passed.

The actual test result is still enforced by `exit "$maestro_exit_code"` inside the Maestro test step, so real test failures continue to fail the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)