### PR TITLE
ci(release): fix Firebase App Distribution auth via wzieba action

### DIFF
--- a/.github/workflows/release-android-base.yaml
+++ b/.github/workflows/release-android-base.yaml
@@ -159,22 +159,16 @@ jobs:
           echo "=== Effective gradle.properties ==="
           cat ${{ inputs.root-path }}/android/gradle.properties
 
-      - name: Setup Firebase
-        uses: w9jds/setup-firebase@main
-        with:
-          tools-version: 13.0.1
-          gcp_sa_key: ${{ secrets.gsa-key }}
-      
       - name: Upload APK to Firebase
         id: firebase-upload
         continue-on-error: false
-        env:
-          APP_ID: ${{ inputs.firebase-app-id }}
-        run: |
-          firebase appdistribution:distribute ${{ inputs.output-path }} \
-            --app $APP_ID \
-            --release-notes "${{ inputs.name }} (${{ inputs.project-type }}) - ${{ inputs.release-type }} - Branch: ${{ github.ref_name }}" \
-            --groups "flutter-team, javascript-team, kotlin-team, unity, rust-team, swift-team, wc-testers"
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ inputs.firebase-app-id }}
+          serviceCredentialsFileContent: ${{ secrets.gsa-key }}
+          groups: flutter-team, javascript-team, kotlin-team, unity, rust-team, swift-team, wc-testers
+          file: ${{ inputs.output-path }}
+          releaseNotes: "${{ inputs.name }} (${{ inputs.project-type }}) - ${{ inputs.release-type }} - Branch: ${{ github.ref_name }}"
     
       - name: Configure AWS credentials
         id: aws-creds

--- a/.github/workflows/release-android-base.yaml
+++ b/.github/workflows/release-android-base.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Upload APK to Firebase
         id: firebase-upload
         continue-on-error: false
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1
         with:
           appId: ${{ inputs.firebase-app-id }}
           serviceCredentialsFileContent: ${{ secrets.gsa-key }}


### PR DESCRIPTION
## Problem

The Android release job fails at **Upload APK to Firebase** with:

```
firebase appdistribution:distribute ...
Error: Failed to authenticate, have you run firebase login?
```

This started after the Firebase service-account key was rotated. The `firebase-tools` CLI does **not** consume the service-account credential exposed via `GOOGLE_APPLICATION_CREDENTIALS` (set by `w9jds/setup-firebase`) for `appdistribution:distribute` — even though the key itself is a valid `service_account` JSON that authenticates fine to the Firebase App Distribution REST API.

## Fix

Replace the raw CLI call with `wzieba/Firebase-Distribution-Github-Action`, which authenticates with the service-account JSON **directly** (`serviceCredentialsFileContent`), bypassing the CLI's broken credential discovery. The now-unused `w9jds/setup-firebase` step is removed (the credential was only used by this upload step — there's no gcloud/build-number step in this workflow).

Reuses the existing `gsa-key` secret — **no secret changes required**.

The identical fix was just verified working in the reown_flutter repo's shared Android release workflow (Firebase upload step went green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)