### PR TITLE
ci(walletkit-e2e): skip E2E on draft PRs + tag runs "(Draft)" for metrics

### DIFF
--- a/.github/workflows/ci_e2e_walletkit.yaml
+++ b/.github/workflows/ci_e2e_walletkit.yaml
@@ -1,5 +1,7 @@
 name: CI E2E WalletKit
-run-name: "E2E WalletKit - ${{ inputs.platform || 'both' }} - Tags: ${{ inputs.maestro-tags || 'pay' }}"
+# The " (Draft)" suffix is consumed by the E2E KPI metrics job (WalletConnect/actions)
+# to exclude draft-PR runs from the P95 feedback stat. Don't change/remove it.
+run-name: "E2E WalletKit - ${{ inputs.platform || 'both' }} - Tags: ${{ inputs.maestro-tags || 'pay' }}${{ github.event.pull_request.draft && ' (Draft)' || '' }}"
 
 permissions:
   contents: read
@@ -59,6 +61,7 @@ jobs:
     if: >-
       always() && inputs.platform != 'android'
       && (github.event_name != 'schedule' || github.event.schedule == '0 9 * * *')
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     name: E2E Tests - iOS
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
@@ -138,7 +141,10 @@ jobs:
 
   e2e-android:
     needs: check-balance
-    if: always() && inputs.platform != 'ios' # Balance alert should not block tests
+    # Balance alert should not block tests
+    if: >-
+      always() && inputs.platform != 'ios'
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     name: E2E Tests - Android
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Why

The **rn** row in the Maestro E2E KPI dashboard showed a **P95 PR feedback of 62m** (vs the usual ~30m). Root cause: one hung `E2E Tests - Android` job on a **draft PR** (#555, the Expo migration) ran for 62m before hitting its 60m timeout and being cancelled. With only **n=8** PR runs in the 7d window, P95 is essentially the max, so that single hung run set the whole metric.

Two contributing problems:
1. Draft PRs run the full iOS/Android E2E on every push — expensive and pure waste on WIP branches.
2. Those draft runs count toward the P95 PR-feedback KPI (which filters `event=pull_request`, any head branch).

## Changes

- **Skip `e2e-ios` / `e2e-android` on draft PRs.** The `github.event_name != 'pull_request'` guard keeps schedule/push/`workflow_dispatch` runs unaffected — only draft *PR* triggers are skipped. (Run E2E on drafts manually via `workflow_dispatch` when needed.)
- **Append `" (Draft)"` to `run-name` for draft-PR runs.** Safety net for the metric: a draft PR still creates a run where `check-balance` executes and the E2E jobs skip, which can end up `success` and be counted. The `(Draft)` tag (surfaced as `display_title` in the runs API) lets the KPI job exclude it.

## Follow-up (separate repo)

To actually honor the tag, `WalletConnect/actions` `metrics/scripts/kpi_p95_feedback.sh` needs a filter on the run selection:
```jq
select((.display_title // "") | contains("(Draft)") | not)
```
Until that lands, the skip-on-draft guard is what does the real work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)