### PR TITLE
ci(maestro): pin actions#105 SHA + fix web Metro cache env poisoning

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -514,14 +514,14 @@ runs:
         curl -fsS -o /dev/null http://localhost:8081 || { echo "Static web server failed:"; cat "${RUNNER_TEMP}/web-serve.log"; exit 1; }
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions#105 (30fd566 — web-only pay flows: in-app
-    # IC form, plus the pay-onchain tags the web leg's parallel/serial split
-    # relies on). NOTE: #105 is still open — re-pin to the squash-merge SHA once merged.
+    # Pinned to the WalletConnect/actions#105 squash-merge SHA (4cec02a on
+    # master — web-only pay flows: in-app IC form, plus the pay-onchain tags the
+    # web leg's parallel/serial split relies on).
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@30fd5666325425f3a01e596e882625c7e96df540
+      uses: WalletConnect/actions/maestro/pay-tests@4cec02a4c535c254581471df287099a26d5eeffb
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@30fd5666325425f3a01e596e882625c7e96df540
+      uses: WalletConnect/actions/maestro/setup@4cec02a4c535c254581471df287099a26d5eeffb
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'
@@ -824,8 +824,8 @@ runs:
       # !cancelled() (not always()): still reset after success/failure, but skip on
       # cancel. Skip too when pay-usdt-polygon didn't run (untagged or excluded).
       if: ${{ !cancelled() && contains(inputs.maestro-tags, 'pay') && !contains(inputs.maestro-exclude-tags, 'pay-usdt-polygon') }}
-      # Pinned to WalletConnect/actions#105 (still open) — re-pin to the merged SHA.
-      uses: WalletConnect/actions/maestro/permit2-reset@30fd5666325425f3a01e596e882625c7e96df540
+      # Pinned to the WalletConnect/actions#105 squash-merge SHA (4cec02a on master).
+      uses: WalletConnect/actions/maestro/permit2-reset@4cec02a4c535c254581471df287099a26d5eeffb
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -480,10 +480,17 @@ runs:
       with:
         # find-cache-dir default (babel-loader / metro transform cache). Warming
         # this across runs cuts most of the `expo export` transform time.
+        #
+        # The key hashes the written .env too: Expo inlines EXPO_PUBLIC_* into
+        # the bundle at Babel transform time, and Metro's transform cache is NOT
+        # keyed on env values — so reusing a cache built with different
+        # EXPO_PUBLIC_* (e.g. a caller injecting per-run ephemeral creds) bakes
+        # stale key/creds into the bundle. No restore-keys: any prefix fallback
+        # would span different .env values and re-introduce that poisoning.
+        # Stable-creds callers still get a full hit (identical .env => identical
+        # key); per-run-creds callers cold-build each run, which is correct.
         path: ${{ steps.paths.outputs.wallet_root }}/node_modules/.cache
-        key: ${{ runner.os }}-web-metro-${{ hashFiles(format('{0}/yarn.lock', steps.paths.outputs.wallet_root)) }}
-        restore-keys: |
-          ${{ runner.os }}-web-metro-
+        key: ${{ runner.os }}-web-metro-${{ hashFiles(format('{0}/yarn.lock', steps.paths.outputs.wallet_root), format('{0}/.env', steps.paths.outputs.wallet_root)) }}
 
     - name: Export web build
       if: inputs.platform == 'web'

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -507,14 +507,14 @@ runs:
         curl -fsS -o /dev/null http://localhost:8081 || { echo "Static web server failed:"; cat "${RUNNER_TEMP}/web-serve.log"; exit 1; }
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions#105 (a6aadae — web-only pay flows: in-app
+    # Pinned to WalletConnect/actions#105 (30fd566 — web-only pay flows: in-app
     # IC form, plus the pay-onchain tags the web leg's parallel/serial split
     # relies on). NOTE: #105 is still open — re-pin to the squash-merge SHA once merged.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@d291974ab5546e76effe98934c146c523e57f9b1
+      uses: WalletConnect/actions/maestro/pay-tests@30fd5666325425f3a01e596e882625c7e96df540
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@d291974ab5546e76effe98934c146c523e57f9b1
+      uses: WalletConnect/actions/maestro/setup@30fd5666325425f3a01e596e882625c7e96df540
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'
@@ -818,7 +818,7 @@ runs:
       # cancel. Skip too when pay-usdt-polygon didn't run (untagged or excluded).
       if: ${{ !cancelled() && contains(inputs.maestro-tags, 'pay') && !contains(inputs.maestro-exclude-tags, 'pay-usdt-polygon') }}
       # Pinned to WalletConnect/actions#105 (still open) — re-pin to the merged SHA.
-      uses: WalletConnect/actions/maestro/permit2-reset@d291974ab5546e76effe98934c146c523e57f9b1
+      uses: WalletConnect/actions/maestro/permit2-reset@30fd5666325425f3a01e596e882625c7e96df540
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}


### PR DESCRIPTION
## Summary

Two changes to `.github/actions/walletkit-build-and-maestro/action.yml`, bundled so downstream repos can test both against a single branch/SHA.

### 1. Pin maestro actions to the merged WalletConnect/actions#105 SHA
`d291974` → `4cec02a4c535c254581471df287099a26d5eeffb` (the squash-merge commit of WalletConnect/actions#105 on `master`) for:
- `WalletConnect/actions/maestro/pay-tests`
- `WalletConnect/actions/maestro/setup`
- `WalletConnect/actions/maestro/permit2-reset`

#105 added the web-only pay flows (in-app IC form) and the `pay-onchain` tags the web leg's parallel/serial split relies on.

### 2. Fix web Metro cache env poisoning
The web `Cache Metro web build cache` step warms `node_modules/.cache` (Expo/Metro's transform `FileStore`). Expo inlines `EXPO_PUBLIC_*` into the bundle **at Babel transform time**, and Metro's transform cache is **not keyed on env values**.

Callers that inject **per-run ephemeral credentials** — e.g. a downstream repo rotating `EXPO_PUBLIC_TEST_PRIVATE_KEY` (and thus the wallet address) every run — restored a cache built with a *different* `.env` and shipped the previous run's address baked into the exported bundle, so Maestro ran against the wrong account.

Fix:
- **Hash the written `.env` into the cache key** (alongside `yarn.lock`).
- **Remove `restore-keys`** — the `<os>-web-metro-` prefix fallback matched any older cache regardless of `.env`, so an exact-key miss still re-poisoned from a stale entry. Exact-match-only is what makes it safe.

Effect:
- **Per-run-creds callers**: `.env` differs every run → key always misses → cold build → correct address inlined.
- **Stable-creds callers** (this repo's E2E CI): `.env` identical across runs → exact key hit → full transform-cache speedup preserved.

Follow-up to #555 (Expo web leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)