### PR TITLE
fix(ci): key web Metro cache on .env to stop stale EXPO_PUBLIC_* poisoning

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -480,10 +480,17 @@ runs:
       with:
         # find-cache-dir default (babel-loader / metro transform cache). Warming
         # this across runs cuts most of the `expo export` transform time.
+        #
+        # The key hashes the written .env too: Expo inlines EXPO_PUBLIC_* into
+        # the bundle at Babel transform time, and Metro's transform cache is NOT
+        # keyed on env values — so reusing a cache built with different
+        # EXPO_PUBLIC_* (e.g. a caller injecting per-run ephemeral creds) bakes
+        # stale key/creds into the bundle. No restore-keys: any prefix fallback
+        # would span different .env values and re-introduce that poisoning.
+        # Stable-creds callers still get a full hit (identical .env => identical
+        # key); per-run-creds callers cold-build each run, which is correct.
         path: ${{ steps.paths.outputs.wallet_root }}/node_modules/.cache
-        key: ${{ runner.os }}-web-metro-${{ hashFiles(format('{0}/yarn.lock', steps.paths.outputs.wallet_root)) }}
-        restore-keys: |
-          ${{ runner.os }}-web-metro-
+        key: ${{ runner.os }}-web-metro-${{ hashFiles(format('{0}/yarn.lock', steps.paths.outputs.wallet_root), format('{0}/.env', steps.paths.outputs.wallet_root)) }}
 
     - name: Export web build
       if: inputs.platform == 'web'


### PR DESCRIPTION
## Problem

The web leg's `Cache Metro web build cache` step warms `node_modules/.cache` (Expo/Metro's transform `FileStore`) across runs. Expo inlines `EXPO_PUBLIC_*` into the bundle **at Babel transform time**, and Metro's transform cache is **not keyed on env values**.

For callers that inject **per-run ephemeral credentials** — e.g. an external repo rotating `EXPO_PUBLIC_TEST_PRIVATE_KEY` (and therefore the wallet address) on every run — the restored cache still holds the *previous* run's address inlined into the bundle. The exported web app ships a stale wallet address, and the Maestro pay flows run against the wrong account.

## Fix

`.github/actions/walletkit-build-and-maestro/action.yml`:

1. **Hash the written `.env` into the cache key** (alongside `yarn.lock`), so a different `EXPO_PUBLIC_*` set produces a different key.
2. **Remove `restore-keys`.** This is the actual bug. `restore-keys: <os>-web-metro-` is a **prefix** fallback that matches any older cache regardless of `.env` — so even with `.env` in the exact key, an exact-key miss falls back to a stale cache and re-poisons. Exact-match-only is what makes it safe.

Ordering is fine: `.env` is written by the `Write wallet .env` step, which runs before this cache step, so `hashFiles(…/.env)` resolves.

## Effect

- **Per-run-creds callers** (the affected external repo): `.env` differs every run → key always misses → cold build → correct address inlined. No more poisoning.
- **Stable-creds callers** (this repo's own E2E CI, which uses fixed `secrets.*`): `.env` identical across runs → exact key hit → full transform-cache speedup preserved.

Note: this repo's in-repo CI uses stable secrets, so it was not actively poisoned; the fix is correct and defensive for the reusable composite action and harmless to in-repo cache performance.

Follow-up to #555 (which added the Expo web leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)