### PR TITLE
ci(maestro): drop universal-link (deeplink) support from wallet E2E

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -498,13 +498,14 @@ runs:
         curl -fsS -o /dev/null http://localhost:8081 || { echo "Static web server failed:"; cat "${RUNNER_TEMP}/web-serve.log"; exit 1; }
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions #109 (28181b5 = removal of the Universal Link
-    # / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer copied.
+    # Pinned to WalletConnect/actions master (4be7c01 = merge of #109, which removes
+    # the Universal Link / deeplink pay flow), so pay_single_option_nokyc_deeplink is
+    # no longer copied.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+      uses: WalletConnect/actions/maestro/pay-tests@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+      uses: WalletConnect/actions/maestro/setup@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'
@@ -801,7 +802,7 @@ runs:
     # steps — actions/runner#1457).
     - name: Reset USDT Permit2 allowance (Polygon)
       if: always() && contains(inputs.maestro-tags, 'pay')
-      uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+      uses: WalletConnect/actions/maestro/permit2-reset@4be7c0112f9651fc63b18c137650b75d2fc9b200
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -213,8 +213,11 @@ runs:
         sudo xcode-select -s "$XCODE_PATH"
         xcodebuild -version
 
+    # Only when a match SSH key is actually provided. The Maestro simulator build
+    # is unsigned by default (no match), and webfactory/ssh-agent errors on an
+    # empty ssh-private-key — so skip the step unless a signing caller passes one.
     - name: Setup SSH for Match
-      if: inputs.platform == 'ios'
+      if: inputs.platform == 'ios' && inputs.match-ssh-key != ''
       uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ inputs.match-ssh-key }}
@@ -315,11 +318,6 @@ runs:
         xcrun simctl boot "$DEVICE_ID" || true
         # Wait for full boot so the steps below don't race a not-ready simulator
         xcrun simctl bootstatus "$DEVICE_ID" -b
-        # Clear stale Shared Web Credentials / associated-domains state on the fresh
-        # boot BEFORE the app is installed, so the install-time applinks binding isn't
-        # wiped by a later reset (which would force a racy AASA re-fetch and leave the
-        # Universal Link unresolved → openurl falls back to Safari).
-        xcrun simctl spawn "$DEVICE_ID" swcutil reset || true
         # Disable UIKit animations to reduce Maestro timing flakiness
         xcrun simctl spawn "$DEVICE_ID" defaults write com.apple.UIKit UIAnimationDragCoefficient 0 || true
         echo "DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
@@ -328,20 +326,6 @@ runs:
       if: inputs.platform == 'ios'
       shell: bash
       run: xcrun simctl install "$DEVICE_ID" "$APP_PATH"
-
-    - name: Prime Universal Link AASA cache
-      if: inputs.platform == 'ios'
-      shell: bash
-      run: |
-        for domain in pay.walletconnect.com staging.pay.walletconnect.com dev.pay.walletconnect.com lab.reown.com; do
-          xcrun simctl spawn "$DEVICE_ID" swcutil dl -d "$domain" || true
-        done
-        sleep 3
-        # Dump the FULL association table (not grep-filtered): swcd's per-app/domain
-        # verdict is what tells us whether the Universal Link will resolve, so it must
-        # be visible in CI logs when the deeplink flow flakes.
-        echo "=== swcutil show (associated-domains state after install + priming) ==="
-        xcrun simctl spawn "$DEVICE_ID" swcutil show 2>/dev/null || true
 
     # --- Android leg ---
     - name: Install Java 17
@@ -514,13 +498,13 @@ runs:
         curl -fsS -o /dev/null http://localhost:8081 || { echo "Static web server failed:"; cat "${RUNNER_TEMP}/web-serve.log"; exit 1; }
 
     # --- Common: Maestro setup + run ---
-    # Pinned to WalletConnect/actions master (ddc7c0f = merge of #106, the
-    # redesigned /collect inline IC flow).
+    # Pinned to WalletConnect/actions #109 (28181b5 = removal of the Universal Link
+    # / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer copied.
     - name: Copy shared Pay test flows
-      uses: WalletConnect/actions/maestro/pay-tests@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+      uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
     - name: Install Maestro
-      uses: WalletConnect/actions/maestro/setup@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+      uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
     - name: Run Maestro tests (iOS)
       if: inputs.platform == 'ios'
@@ -541,14 +525,10 @@ runs:
       run: |
         xcrun simctl launch "$DEVICE_ID" "$APP_ID" || true
         mkdir -p maestro-artifacts
-        # Snapshot the associated-domains verification state at run start — brackets the
-        # post-install dump above and shows swcd's verdict closer to the deeplink flow.
-        echo "=== swcutil show (Maestro run start) ==="
-        xcrun simctl spawn "$DEVICE_ID" swcutil show 2>/dev/null || true
         xcrun simctl spawn "$DEVICE_ID" log stream \
           --level=debug \
           --style=compact \
-          --predicate "process == \"RNWallet-Internal\" OR senderImagePath CONTAINS \"RNWallet\" OR process CONTAINS \"maestro\" OR process == \"xctest\" OR process == \"testmanagerd\" OR process == \"tccd\" OR process == \"SpringBoard\" OR process == \"swcd\" OR process == \"swcagent\"" \
+          --predicate "process == \"RNWallet-Internal\" OR senderImagePath CONTAINS \"RNWallet\" OR process CONTAINS \"maestro\" OR process == \"xctest\" OR process == \"testmanagerd\" OR process == \"tccd\" OR process == \"SpringBoard\"" \
           > maestro-artifacts/ios-syslog.log 2>&1 &
         SYSLOG_PID=$!
         set +e
@@ -706,15 +686,15 @@ runs:
         # Rewrite the shared flows for web: appId:->url: (Maestro targets the
         # browser via the URL), strip start/stopRecording (unsupported on web),
         # and drop the flows that can't run in a browser — hosted-KYC-webview
-        # flows (replaced by pay_*_web), the deeplink flow, and the multi-option
-        # no-KYC flow whose option->review correlation reads accessibilityLabel
-        # (Maestro web can't), replaced by pay_multiple_options_nokyc_web.
+        # flows (replaced by pay_*_web) and the multi-option no-KYC flow whose
+        # option->review correlation reads accessibilityLabel (Maestro web can't),
+        # replaced by pay_multiple_options_nokyc_web.
         WEB_FLOWS_DIR="$(mktemp -d)"
         cp -R .maestro/. "$WEB_FLOWS_DIR/"
         find "$WEB_FLOWS_DIR" -name '*.yaml' -print0 \
           | xargs -0 perl -ni -e 'next if /^\s*-?\s*(start|stop)Recording\b/; s/^appId:(\s*\$\{APP_ID\})/url:$1/; print'
         for f in pay_kyc_back_navigation pay_cancel_from_kyc pay_multiple_options_kyc \
-                 pay_multiple_options_nokyc pay_single_option_nokyc_deeplink; do
+                 pay_multiple_options_nokyc; do
           rm -f "$WEB_FLOWS_DIR/$f.yaml"
         done
         mkdir -p maestro-artifacts maestro-artifacts/maestro-debug
@@ -821,7 +801,7 @@ runs:
     # steps — actions/runner#1457).
     - name: Reset USDT Permit2 allowance (Polygon)
       if: always() && contains(inputs.maestro-tags, 'pay')
-      uses: WalletConnect/actions/maestro/permit2-reset@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+      uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
       with:
         chain-id: eip155:137
         rpc-url: ${{ inputs.polygon-rpc-url }}

--- a/.github/workflows/ci_e2e_walletkit.yaml
+++ b/.github/workflows/ci_e2e_walletkit.yaml
@@ -105,12 +105,6 @@ jobs:
           merchant-api-key-multi-kyc: ${{ secrets.WPAY_CUSTOMER_KEY_MULTI_KYC }}
           merchant-id-multi-kyc: ${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }}
           maestro-tags: ${{ env.MAESTRO_TAGS }}
-          apple-key-id: ${{ secrets.APPLE_KEY_ID }}
-          apple-key-content: ${{ secrets.APPLE_KEY_CONTENT }}
-          apple-issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
-          match-git-url: ${{ secrets.MATCH_GIT_URL }}
-          match-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
-          match-ssh-key: ${{ secrets.MATCH_SSH_KEY }}
 
       - name: Send Slack notification
         if: failure()

--- a/scripts/run-maestro-pay-tests.sh
+++ b/scripts/run-maestro-pay-tests.sh
@@ -112,19 +112,16 @@ if [[ "$APP_ID" == http://* || "$APP_ID" == https://* ]]; then
   #   - KYC webview flows: the identity-collection form sends X-Frame-Options DENY,
   #     so on web it opens in a NEW TAB (Maestro drives a single tab) and its
   #     callback is HTTPS-only — the form leg can't complete under local web.
-  #   - deeplink/universal-link: `openLink` of the wallet's custom scheme/universal
-  #     link isn't handled by the web build.
   # KYC-webview flows are replaced on web by in-app-form variants tagged
   # `pay-web` (pay_kyc_web, pay_cancel_from_kyc_web). The multi-option no-KYC
   # flow correlates option->review via the option's accessibilityLabel (network
   # name), which Maestro web can't read; pay_multiple_options_nokyc_web covers
-  # the rest. The deeplink flow opens a universal link the web build won't handle.
+  # the rest.
   WEB_SKIP_FLOWS=(
     pay_kyc_back_navigation.yaml      # asserts KYC webview back/close (mobile-only)
     pay_cancel_from_kyc.yaml          # hosted KYC webview -> see pay_cancel_from_kyc_web
     pay_multiple_options_kyc.yaml     # hosted KYC webview -> see pay_kyc_web
     pay_multiple_options_nokyc.yaml   # aria-label correlation -> see pay_multiple_options_nokyc_web
-    pay_single_option_nokyc_deeplink.yaml  # opens a universal link / deeplink
   )
   for flow in "${WEB_SKIP_FLOWS[@]}"; do
     if rm -f "$WEB_FLOWS_DIR/$flow" 2>/dev/null && [ ! -e "$WEB_FLOWS_DIR/$flow" ]; then

--- a/wallets/rn_cli_wallet/app.json
+++ b/wallets/rn_cli_wallet/app.json
@@ -16,10 +16,7 @@
       "supportsTablet": true,
       "associatedDomains": [
         "applinks:appkit-lab.reown.com",
-        "applinks:lab.reown.com",
-        "applinks:pay.walletconnect.com",
-        "applinks:staging.pay.walletconnect.com",
-        "applinks:dev.pay.walletconnect.com"
+        "applinks:lab.reown.com"
       ],
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Our app does not request this permission or utilize this functionality but it is included in our info.plist since our app utilizes the react-native-permissions library."
@@ -42,16 +39,6 @@
           "data": [
             { "scheme": "https", "host": "appkit-lab.reown.com", "pathPrefix": "/rn_walletkit" },
             { "scheme": "https", "host": "lab.reown.com", "pathPrefix": "/rn_walletkit" }
-          ]
-        },
-        {
-          "action": "VIEW",
-          "autoVerify": true,
-          "category": ["DEFAULT", "BROWSABLE"],
-          "data": [
-            { "scheme": "https", "host": "pay.walletconnect.com" },
-            { "scheme": "https", "host": "staging.pay.walletconnect.com" },
-            { "scheme": "https", "host": "dev.pay.walletconnect.com" }
           ]
         }
       ]

--- a/wallets/rn_cli_wallet/src/screens/App.tsx
+++ b/wallets/rn_cli_wallet/src/screens/App.tsx
@@ -115,7 +115,9 @@ const App = () => {
         return;
       }
 
-      // 2. Payment link from NFC tag or App Link (pay.walletconnect.com)
+      // 2. Payment link from NFC tag (pay.walletconnect.com). Universal-link
+      // registration for these hosts was removed from app.json, so on native
+      // these URLs now arrive via NFC rather than a tapped App Link.
       try {
         const { hostname } = new URL(url);
         if (


### PR DESCRIPTION
## Summary

Universal linking is no longer in scope for the wallet Maestro pay suite — [WalletConnect/actions#109](https://github.com/WalletConnect/actions/pull/109) removed the Universal Link pay test (`pay_single_option_nokyc_deeplink.yaml`) from the shared suite. This PR strips the infrastructure in this repo that existed **only** to make that test pass.

## Changes

- **Stop registering `pay.walletconnect` universal links** (`app.json`): remove the `applinks:pay.walletconnect.*` entries from iOS `associatedDomains` and the `autoVerify` `pay.walletconnect` Android `intentFilters` block. Kept `lab.reown.com` / `appkit-lab.reown.com` (real dApp deep-link-back / link-mode). The JS pay-link handler in `App.tsx` stays — pay links still reach the wallet via **NFC**.
- **Stop signing the Maestro iOS simulator build** (`ci_e2e_walletkit.yaml`): drop the signing secrets from the `e2e-ios` job so the build is unsigned (`skip_codesigning`) → faster iOS builds (no `match` clone / keychain). Signing (dev, never prod) was only needed to verify the `applinks:` associated-domains entitlement for the UL test. `release_testflight` is untouched. The `Setup SSH for Match` step in the action is now guarded on a non-empty key.
- **Simplify the iOS Simulator boot** (`action.yml`): remove `swcutil reset`, the `Prime Universal Link AASA cache` step, the run-start `swcutil show` dump, and `swcd`/`swcagent` from the log-stream predicate.
- **Bump the shared-flows pins** (`action.yml`): `pay-tests`, `setup`, `permit2-reset` pinned to the merged 109 commit (`4be7c01` on `WalletConnect/actions` master) so the deeplink flow is no longer downloaded; removed the now-dead deeplink web-skip entries here and in `scripts/run-maestro-pay-tests.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)