### PR TITLE
ci(e2e): skip WalletKit + POS E2E on Dependabot PRs

### DIFF
--- a/.github/workflows/ci_e2e_tests_pos_web.yaml
+++ b/.github/workflows/ci_e2e_tests_pos_web.yaml
@@ -34,8 +34,11 @@ jobs:
   e2e:
     name: Maestro POS App E2E Tests (Web · preview)
     # Skip while the PR is a draft; runs once it's marked ready for review.
-    # workflow_dispatch is unaffected.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # workflow_dispatch is unaffected. Dependabot PRs can't read repo secrets
+    # (Slack webhook), so skip them entirely.
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci_e2e_walletkit.yaml
+++ b/.github/workflows/ci_e2e_walletkit.yaml
@@ -68,7 +68,11 @@ jobs:
   check-balance:
     # Skip the faucet/balance check on draft PRs too — the E2E jobs that need it
     # are skipped while a PR is a draft, so there's nothing to check for.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # Dependabot PRs can't read repo secrets (wallet env, faucet webhook), so the
+    # E2E jobs would always fail — skip the whole workflow for them.
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: ./.github/workflows/e2e-balance-check.yml
     secrets:
       SLACK_FAUCETBOT_WEBHOOK_URL: ${{ secrets.SLACK_FAUCETBOT_WEBHOOK_URL }}
@@ -80,6 +84,7 @@ jobs:
     # dispatch, gated by the `ios` checkbox.
     if: >-
       always()
+      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'workflow_dispatch' || inputs.ios)
       && (github.event_name != 'schedule' || github.event.schedule == '0 9 * * *')
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
@@ -159,7 +164,8 @@ jobs:
     # Balance alert should not block tests. Android runs on every trigger (it's
     # the cheap 6h canary); on dispatch, gated by the `android` checkbox.
     if: >-
-      always() && (github.event_name != 'workflow_dispatch' || inputs.android)
+      always() && github.actor != 'dependabot[bot]'
+      && (github.event_name != 'workflow_dispatch' || inputs.android)
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     name: E2E Tests - Android
     runs-on: ubuntu-latest
@@ -242,6 +248,7 @@ jobs:
     # for parity with iOS's daily-only schedule gate.
     if: >-
       always()
+      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'workflow_dispatch' || inputs.web)
       && (github.event_name != 'schedule' || github.event.schedule == '0 9 * * *')
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)


### PR DESCRIPTION
## Why

Dependabot-authored PRs run with a restricted token and **cannot read the repo's Actions secrets** (wallet env file, faucet/Slack webhooks). When a Dependabot bump touches a triggering path (e.g. `wallets/rn_cli_wallet/**`), these E2E suites fire but fail immediately at the secrets guard:

```
Error: either wallet-env-file or reown-project-id must be provided
##[error]Process completed with exit code 1.
```

…and again on the `Send Slack notification` step (`Missing input! Either a method or webhook is required`). These are pure false-reds — they say nothing about the dependency bump — and the failed PR run also leaks into the metrics **P95 PR-feedback** sample (`event=pull_request`, no branch filter). Example: run [#29845719000](https://github.com/reown-com/react-native-examples/actions/runs/29845719000) on the `brace-expansion` bump.

## Change

Gate every affected job on `github.actor != 'dependabot[bot]'` so Dependabot runs skip cleanly (run conclusion `skipped`, which the KPI scripts already ignore — pass/flake filter to `branch=main`, P95 keeps only `success`/`failure`).

- **`ci_e2e_walletkit.yaml`** — all 4 jobs (`check-balance`, `e2e-ios`, `e2e-android`, `e2e-web`). The E2E jobs use `always()`, so the guard must be per-job, not just on `check-balance`.
- **`ci_e2e_tests_pos_web.yaml`** — the `e2e` job. Its Maestro run hits a Vercel preview and needs no secrets, but the on-failure Slack step does, so the guard keeps it consistent.

Human PRs, cron, push, and `workflow_dispatch` are unaffected.

## Not included

`ci_e2e_tests_ios.yaml` and `ci_e2e_tests_android.yaml` have the same exposure — happy to add the guard there in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)