### PR TITLE
refactor(appkit-wagmi): drop onOpenWindow/setSupportMultipleWindows from PayWebView

### DIFF
--- a/dapps/appkit-wagmi/src/screens/PayWebView/index.tsx
+++ b/dapps/appkit-wagmi/src/screens/PayWebView/index.tsx
@@ -4,10 +4,7 @@ import {
   WebView,
   WebViewMessageEvent
 } from 'react-native-webview';
-import type {
-  ShouldStartLoadRequest,
-  WebViewOpenWindowEvent,
-} from 'react-native-webview/lib/WebViewTypes';
+import type {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes';
 import {RootStackScreenProps} from '@/utils/TypesUtil';
 import {ToastUtils} from '@/utils/ToastUtils';
 import {PaySuccessView} from './PaySuccessView';
@@ -34,7 +31,7 @@ function PayWebView({route, navigation}: RootStackScreenProps<'PayWebView'>) {
   const {url} = route.params;
 
   // Once the Pay page reports success we swap the WebView for the success
-  // result screen (Lottie checkmark), mirroring the wallet sample's Pay flow.
+  // result screen (Lottie checkmark).
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const onShouldStartLoadWithRequest = useCallback(
@@ -52,26 +49,6 @@ function PayWebView({route, navigation}: RootStackScreenProps<'PayWebView'>) {
     },
     [],
   );
-
-  // Some pages open the wallet via window.open() (a new window) rather than a
-  // same-frame navigation, which routes here instead of onShouldStartLoadWithRequest.
-  // Only hand wallet deeplinks off to the OS — ignore any other window.open()
-  // target so a page can't drive Linking.openURL to arbitrary native schemes
-  // (tel:/sms:/intent:...). This mirrors the isWalletDeeplink gate above, which
-  // also matches https universal links (they carry the same `uri=wc:` param),
-  // so preferUniversalLinks wallets keep working.
-  const onOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
-    const {targetUrl} = event.nativeEvent;
-    if (!isWalletDeeplink(targetUrl)) {
-      return;
-    }
-    Linking.openURL(targetUrl).catch(() => {
-      ToastUtils.showErrorToast(
-        "Couldn't open wallet",
-        'The wallet app may not be installed.',
-      );
-    });
-  }, []);
 
   const onMessage = useCallback(
     (event: WebViewMessageEvent) => {
@@ -128,9 +105,7 @@ function PayWebView({route, navigation}: RootStackScreenProps<'PayWebView'>) {
       startInLoadingState
       javaScriptEnabled
       domStorageEnabled
-      setSupportMultipleWindows
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-      onOpenWindow={onOpenWindow}
       onMessage={onMessage}
       onError={onLoadError}
     />

--- a/dapps/appkit-wagmi/src/screens/PayWebView/index.tsx
+++ b/dapps/appkit-wagmi/src/screens/PayWebView/index.tsx
@@ -1,9 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import {Linking, StyleSheet} from 'react-native';
-import {
-  WebView,
-  WebViewMessageEvent
-} from 'react-native-webview';
+import {WebView} from 'react-native-webview';
+import type {WebViewMessageEvent} from 'react-native-webview';
 import type {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes';
 import {RootStackScreenProps} from '@/utils/TypesUtil';
 import {ToastUtils} from '@/utils/ToastUtils';


### PR DESCRIPTION
## Summary

Removes the `onOpenWindow` handler and `setSupportMultipleWindows` prop from the `appkit-wagmi` sample dapp's `PayWebView`, since they were dead code for the wallet-open path.

## Why it's safe

The `PayWebView` loads the WalletConnect Pay web page, whose **web AppKit** (`@reown/appkit-controllers`) opens a tapped wallet via:

```js
// onConnectMobile → openHref
const target = CoreHelperUtil.isIframe() ? '_top' : '_self';
window.open(deepLink /* or universalLink */, target);
```

Inside the RN WebView `isIframe()` is `false` → `target = '_self'`, i.e. a **same-frame navigation**. `react-native-webview` routes same-frame navigations to `onShouldStartLoadWithRequest` (kept), **never** `onOpenWindow` (which only fires for new-window `window.open`, requiring `setSupportMultipleWindows`).

Both the native deeplink and the `preferUniversalLinks` universal link carry `uri=wc:`, so `isWalletDeeplink()` matches them in `onShouldStartLoadWithRequest` → `Linking.openURL` → wallet opens. AppKit never uses a new-window open for the wallet list (`_blank` is only for store/install links), so nothing was ever flowing through `onOpenWindow`.

## Testing

- Verified against `@reown/appkit-controllers@1.8.22` source (`ConnectionControllerUtil.onConnectMobile` / `CoreHelperUtil.openHref`).
- Manually confirmed wallets still open from the list with `onOpenWindow` removed.

## Also

- Trimmed a now-inaccurate comment and a redundant clause; dropped the unused `WebViewOpenWindowEvent` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)